### PR TITLE
Adopt pytest discovery for existing tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py *_test.py *_tests.py
+python_classes = Test* *Tests
+python_functions = test_*
+addopts =
+    --tb=short
+    --strict-markers
+markers =
+    assimulo: tests that require the Assimulo ODE/DAE solver stack
+    integration: integration tests that exercise full unit-operation solves
+    slow: long-running tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,12 @@ python_functions = test_*
 addopts =
     --tb=short
     --strict-markers
+faulthandler_timeout = 300
+filterwarnings =
+    error::pytest.PytestUnhandledThreadExceptionWarning
+    error::pytest.PytestUnraisableExceptionWarning
 markers =
     assimulo: tests that require the Assimulo ODE/DAE solver stack
     integration: integration tests that exercise full unit-operation solves
     slow: long-running tests
+    unit: fast tests that do not require solver-backed integration

--- a/tests/Flowsheet/flowsheet_tests.py
+++ b/tests/Flowsheet/flowsheet_tests.py
@@ -8,24 +8,39 @@ Created on Mon Jan 22 18:28:36 2024
 
 import unittest
 import os
+import importlib.util
 import numpy as np
+import pytest
 from copy import deepcopy
-from PharmaPy.Reactors import BatchReactor, SemibatchReactor, PlugFlowReactor
-from PharmaPy.Containers import DynamicCollector
-from PharmaPy.Crystallizers import BatchCryst, MSMPR
-from PharmaPy.SolidLiquidSep import Filter
 
-from PharmaPy.Streams import LiquidStream, SolidStream
-from PharmaPy.Phases import LiquidPhase, SolidPhase
-from PharmaPy.MixedPhases import SlurryStream
+HAS_ASSIMULO = importlib.util.find_spec("assimulo") is not None
+pytestmark = [
+    pytest.mark.assimulo,
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not HAS_ASSIMULO,
+        reason="assimulo is not installed; solver-backed integration tests skipped",
+    ),
+]
 
-from PharmaPy.Kinetics import RxnKinetics, CrystKinetics
+if HAS_ASSIMULO:
+    from PharmaPy.Reactors import BatchReactor, SemibatchReactor, PlugFlowReactor
+    from PharmaPy.Containers import DynamicCollector
+    from PharmaPy.Crystallizers import BatchCryst, MSMPR
+    from PharmaPy.SolidLiquidSep import Filter
 
-from PharmaPy.Utilities import CoolingWater
-from PharmaPy.Interpolation import PiecewiseLagrange
-from PharmaPy.ProcessControl import DynamicInput
+    from PharmaPy.Streams import LiquidStream, SolidStream
+    from PharmaPy.Phases import LiquidPhase, SolidPhase
+    from PharmaPy.MixedPhases import SlurryStream
 
-from PharmaPy.SimExec import SimulationExec
+    from PharmaPy.Kinetics import RxnKinetics, CrystKinetics
+
+    from PharmaPy.Utilities import CoolingWater
+    from PharmaPy.Interpolation import PiecewiseLagrange
+    from PharmaPy.ProcessControl import DynamicInput
+
+    from PharmaPy.SimExec import SimulationExec
 
 
 class TestFlowsheets(unittest.TestCase):
@@ -328,4 +343,3 @@ class TestFlowsheets(unittest.TestCase):
         
 if __name__ == '__main__':
     unittest.main()
-    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+
+TESTS_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = TESTS_ROOT.parent
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _has_assimulo():
+    try:
+        import assimulo  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.fixture(scope="session")
+def data_path():
+    return {
+        "integration": TESTS_ROOT / "integration" / "data",
+        "flowsheet": TESTS_ROOT / "Flowsheet" / "data",
+    }
+
+
+def pytest_collection_modifyitems(config, items):
+    if _has_assimulo():
+        return
+
+    skip_assimulo = pytest.mark.skip(
+        reason="assimulo is not installed; solver-backed integration tests skipped"
+    )
+    for item in items:
+        if "assimulo" in item.keywords:
+            item.add_marker(skip_assimulo)

--- a/tests/integration/reactor_tests.py
+++ b/tests/integration/reactor_tests.py
@@ -7,14 +7,28 @@ Created on Mon Apr 18 10:57:33 2022
 
 import unittest
 import json
+import importlib.util
 from glob import glob
+from pathlib import Path
 from  numpy import genfromtxt, savetxt, allclose, vstack
+import pytest
 
-from PharmaPy.Reactors import PlugFlowReactor
-from PharmaPy.Streams import LiquidStream
-from PharmaPy.Phases import LiquidPhase
-from PharmaPy.Kinetics import RxnKinetics
-from PharmaPy.Utilities import CoolingWater
+HAS_ASSIMULO = importlib.util.find_spec("assimulo") is not None
+pytestmark = [
+    pytest.mark.assimulo,
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not HAS_ASSIMULO,
+        reason="assimulo is not installed; solver-backed integration tests skipped",
+    ),
+]
+
+if HAS_ASSIMULO:
+    from PharmaPy.Reactors import PlugFlowReactor
+    from PharmaPy.Streams import LiquidStream
+    from PharmaPy.Phases import LiquidPhase
+    from PharmaPy.Kinetics import RxnKinetics
+    from PharmaPy.Utilities import CoolingWater
 
 
 class PlugFlowReactorTests(unittest.TestCase):
@@ -23,9 +37,10 @@ class PlugFlowReactorTests(unittest.TestCase):
 
     def setUp(self):
         # Data
-        datapath = 'data/pfr_test_pure_comp.json'
+        data_dir = Path(__file__).resolve().parent / 'data'
+        datapath = str(data_dir / 'pfr_test_pure_comp.json')
 
-        with open('data/pfr_test_constructor_kwargs.json') as f:
+        with open(data_dir / 'pfr_test_constructor_kwargs.json') as f:
             data_objects = json.load(f)
 
         tau = data_objects['inlet'].pop('tau')
@@ -34,7 +49,7 @@ class PlugFlowReactorTests(unittest.TestCase):
         data_objects['kinetics']['k_params'] *= 1/60
         data_objects['kinetics']['path'] = datapath
 
-        time_integration = genfromtxt('data/pfr_test_expected_times.csv',
+        time_integration = genfromtxt(data_dir / 'pfr_test_expected_times.csv',
                                       delimiter=',')
 
         data_objects['solve_unit']['time_grid'] = time_integration
@@ -56,7 +71,8 @@ class PlugFlowReactorTests(unittest.TestCase):
         reactor.solve_unit(**data_objects['solve_unit'])
 
     def test_mole_conc(self):
-        filenames = glob('data/pfr_test_expected_conc*')
+        data_dir = Path(__file__).resolve().parent / 'data'
+        filenames = glob(str(data_dir / 'pfr_test_expected_conc*'))
         filenames.sort(key=lambda f: int(''.join(filter(str.isdigit, f))))
 
         flags = []

--- a/tests/test_pytest_discovery.py
+++ b/tests/test_pytest_discovery.py
@@ -1,0 +1,3 @@
+def test_data_path_fixture_resolves_existing_test_data(data_path):
+    assert (data_path["integration"] / "pfr_test_pure_comp.json").is_file()
+    assert (data_path["flowsheet"] / "compound_database.json").is_file()

--- a/tests/test_pytest_discovery.py
+++ b/tests/test_pytest_discovery.py
@@ -1,3 +1,9 @@
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
 def test_data_path_fixture_resolves_existing_test_data(data_path):
     assert (data_path["integration"] / "pfr_test_pure_comp.json").is_file()
     assert (data_path["flowsheet"] / "compound_database.json").is_file()


### PR DESCRIPTION
## Summary

- Adds minimal pytest discovery configuration for the existing legacy test modules.
- Registers the `unit`, `assimulo`, `integration`, and `slow` markers, plus conservative pytest timeout diagnostics and warning filters.
- Marks the current solver-backed tests as `assimulo`/`integration` so missing Assimulo skips cleanly instead of failing collection.
- Makes the PFR test data paths independent of the current working directory.
- Adds a tiny non-solver discovery fixture test so the future core CI has at least one non-Assimulo test to run.

## Traceability

Closes #4.
Refs SECQUOIA/PharmaPy#1, SECQUOIA/PharmaPy#2, CryPTSys/PharmaPy#106, and CryPTSys/PharmaPy#107.

## Checks

- `python -m pytest --collect-only -q -rs` -> 7 tests collected
- `python -m pytest tests/ -m "unit" -rs` -> 1 passed, 6 deselected
- `python -m pytest tests/ -m "not assimulo" -rs` -> 1 passed, 6 deselected
- `python -m pytest` -> 1 passed, 6 skipped because Assimulo is not installed in the active interpreter
- From `/tmp`: `python -m pytest /tmp/pharmapy-pr90-address/tests/ -m "not assimulo" -rs` -> 1 passed, 6 deselected

## Branch Hygiene

- Base: `master`
- Head: `test/pytest-discovery-fixtures`
- Stacked status: root PR in the infrastructure re-introduction stack

## CI

GitHub Actions is not configured on `master` yet. The next PR adds the workflow and will provide the first Actions execution proof.
