### PR TITLE
Add minimal core GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
       - "**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   core-tests:
     name: Core tests
@@ -27,7 +34,7 @@ jobs:
       - name: Install core dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "numpy<2" "cython<3" "scipy<1.14" matplotlib pandas pytest
+          python -m pip install "numpy<2" "scipy<1.14" matplotlib pandas pytest
           python -m pip install -e . --no-deps
 
       - name: Collect tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+  workflow_dispatch:
+
+jobs:
+  core-tests:
+    name: Core tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install core dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "numpy<2" "cython<3" "scipy<1.14" matplotlib pandas pytest
+          python -m pip install -e . --no-deps
+
+      - name: Collect tests
+        run: python -m pytest --collect-only
+
+      - name: Run assimulo-free tests
+        run: python -m pytest tests/ -m "not assimulo"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <img align="left" src="./doc/online_docs/images/PharmaPy_logo.jpeg" alt="PharmaPy_logo" height="250">
 
 <!-- BEGIN Status badges -->
+[![CI](https://github.com/SECQUOIA/PharmaPy/actions/workflows/ci.yml/badge.svg)](https://github.com/SECQUOIA/PharmaPy/actions/workflows/ci.yml)
 ![GitHub all releases](https://img.shields.io/github/downloads/CryPTSys/PharmaPy/total)
 [![DOI](https://img.shields.io/badge/DOI-10.1016%2Fj.compchemeng.2021.107408-blue)](https://www.sciencedirect.com/science/article/abs/pii/S0098135421001861)
 <!-- END Status badges -->
@@ -17,6 +18,5 @@ It allows to simulate the dynamics of standalone, drug substance unit operations
 To install PharmaPy, download and unzip the code from the release section, and then follow the instructions on the `install_instructions.txt` file.
 
 Read our [documentation](https://pharmapy.readthedocs.io/en/latest/) or chat with the [PharmaPy Simulation Assistant](https://chatgpt.com/g/g-679bb3b5c5188191b26680b147a4f4a2-pharmapy-simulation-assistant) for more information on how to install and how to use PharmaPy.
-
 
 


### PR DESCRIPTION
## Summary

- Adds a minimal GitHub Actions workflow for core, assimulo-free test execution.
- Runs on `push`, `pull_request`, and `workflow_dispatch`.
- Keeps `branches: ["**"]` intentionally while the stack is landing so branch pushes on stacked PRs exercise the workflow before it exists on `master`.
- Adds read-only `GITHUB_TOKEN` permissions and concurrency cancellation for redundant branch/PR runs.
- Installs core scientific dependencies explicitly and installs PharmaPy editable with `--no-deps` to avoid the current hard Assimulo requirement until #8/#9 land.
- Runs pytest collection and the `not assimulo` test subset introduced in #90.
- Adds the CI status badge to `README.md`.

## Traceability

Closes #5.
Depends on merged #90 / #4.
Refs SECQUOIA/PharmaPy#1, SECQUOIA/PharmaPy#2, CryPTSys/PharmaPy#106, and CryPTSys/PharmaPy#107.

## Checks

- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text())"` -> `yaml ok`
- Python 3.11.14 venv:
  - `python -m pip install --upgrade pip` -> passed
  - `python -m pip install "numpy<2" "scipy<1.14" matplotlib pandas pytest` -> passed
  - `python -m pip install -e . --no-deps` -> passed
  - `python -m pytest --collect-only -q -rs` -> 7 tests collected
  - `python -m pytest tests/ -m "not assimulo" -rs` -> 1 passed, 6 deselected
  - `python -m pytest -rs` -> 1 passed, 6 skipped because Assimulo is not installed
- Local default interpreter:
  - `python -m pytest --collect-only -q -rs` -> 7 tests collected
  - `python -m pytest tests/ -m "not assimulo" -rs` -> 1 passed, 6 deselected
  - `python -m pytest -rs` -> 1 passed, 6 skipped
- `git diff --check` -> passed

## Branch Hygiene

- Base: `master`
- Head: `ci/minimal-core-tests`
- Stacked status: follows merged #90.

## CI

This PR introduces the workflow. Branch-push Actions runs should execute from the PR head; pull-request checks may remain limited until the workflow exists on the target base branch.
