### PR TITLE
Relax dependency bounds and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-runtime:
+        patterns:
+          - "numpy"
+          - "scipy"
+          - "matplotlib"
+          - "pandas"
+      python-test:
+        patterns:
+          - "pytest"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Install core dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "numpy<2" "cython<3" "scipy<1.14" matplotlib pandas pytest
-          python -m pip install -e . --no-deps
+          python -m pip install -e ".[test]"
 
       - name: Collect tests
         run: python -m pytest --collect-only

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,18 @@
+# Dependency Policy
+
+The default install keeps only the core runtime dependencies. Assimulo is an
+optional solver dependency because it is difficult to build on common pip-only
+environments and is only needed for the solver-backed unit-operation models.
+
+Current bounds:
+
+- `numpy>=1.22`: the lower bound gives a modern baseline for supported Python
+  versions while allowing the NumPy 2 line to be exercised by CI and Dependabot.
+- `scipy>=1.9`: the previous SciPy upper cap was tied to
+  `scipy.integrate.simps`, which was removed in SciPy 1.14. PharmaPy now uses
+  `scipy.integrate.simpson`, so current SciPy releases can be tested directly.
+- `matplotlib>=3.5` and `pandas>=1.5`: lower bounds avoid unbounded old
+  releases while leaving current releases open for Dependabot and CI.
+- `cython>=0.29,<3` and `assimulo==3.4.3`: these are confined to the
+  `assimulo` optional extra until the Assimulo integration job proves a broader
+  solver stack works.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include LICENSE.md
 include README.md
+include DEPENDENCIES.md
 include requirements.txt
+include requirements-assimulo.txt
 include install_instructions.txt
 include InstallOnMac.sh
 include InstallOnWindows.bat

--- a/PharmaPy/Commons.py
+++ b/PharmaPy/Commons.py
@@ -9,10 +9,14 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import AutoMinorLocator
 # from autograd import numpy as np
 import numpy as np
-from scipy.integrate import simps
+from scipy.integrate import simpson
 from itertools import cycle
 
-from assimulo.exception import TerminateSimulation
+try:
+    from assimulo.exception import TerminateSimulation
+except ImportError:
+    class TerminateSimulation(Exception):
+        """Fallback used when optional Assimulo solvers are not installed."""
 
 linestyles = cycle(['-', '--', '-.', ':'])
 eps = np.finfo(float).eps
@@ -583,7 +587,7 @@ def integration(states, time):
 
     integral = np.zeros(states.shape[1])
     for ind, row in enumerate(states.T):
-        integral[ind] = simps(row, time)
+        integral[ind] = simpson(row, x=time)
 
     return integral
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,17 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Chemistry",
 ]
 dependencies = [
-    "numpy<2",
-    "cython<3",
-    "scipy<1.14",
-    "assimulo==3.4.3",
-    "matplotlib",
-    "pandas",
+    "numpy>=1.22",
+    "scipy>=1.9",
+    "matplotlib>=3.5",
+    "pandas>=1.5",
 ]
 
 [project.optional-dependencies]
+assimulo = [
+    "cython>=0.29,<3",
+    "assimulo==3.4.3",
+]
 test = [
     "pytest",
 ]

--- a/requirements-assimulo.txt
+++ b/requirements-assimulo.txt
@@ -1,0 +1,4 @@
+# Optional solver stack for Assimulo-backed models and integration tests.
+-r requirements.txt
+cython>=0.29,<3
+assimulo==3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-numpy<2
-cython<3
-scipy<1.14
-assimulo==3.4.3
-matplotlib
-pandas
+# Core runtime dependencies. See DEPENDENCIES.md for the remaining caps.
+numpy>=1.22
+scipy>=1.9
+matplotlib>=3.5
+pandas>=1.5

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pytest
+
+
+def test_commons_integration_imports_without_assimulo():
+    from PharmaPy import Commons
+
+    time = np.array([0.0, 1.0, 2.0])
+    states = np.array([0.0, 1.0, 2.0])
+
+    integral = Commons.integration(states, time)
+
+    assert integral.shape == (1,)
+    assert integral[0] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- Move Assimulo out of the core install and into the optional assimulo extra.
- Replace blanket pins with lower bounds for NumPy, SciPy, matplotlib, and pandas.
- Migrate Commons.integration from scipy.integrate.simps to simpson so current SciPy releases are installable.
- Add DEPENDENCIES.md, requirements-assimulo.txt, and weekly Dependabot groups for pip and GitHub Actions.
- Update CI to install the package through python -m pip install -e ".[test]".

## Traceability
Closes #9.
Depends on #92 / #8 and is stacked on packaging/pyproject-metadata.
Refs SECQUOIA/PharmaPy#1, SECQUOIA/PharmaPy#2, CryPTSys/PharmaPy#106, and CryPTSys/PharmaPy#107.

## Verification
- python -m pip install -e ".[test]"
- pytest --collect-only
- pytest tests/ -m "not assimulo"
- python -m build (rerun with network access for isolated setuptools/wheel build requirements)

## Actions
GitHub Actions should run on this PR through the stacked CI workflow from #91.