### PR TITLE
Add optional Assimulo integration CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,35 @@ jobs:
 
       - name: Run assimulo-free tests
         run: python -m pytest tests/ -m "not assimulo"
+
+  integration-assimulo:
+    name: Assimulo integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install system solver libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gfortran liblapack-dev libblas-dev
+
+      - name: Set up conda environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          use-mamba: true
+          environment-file: environment.yml
+          activate-environment: pharmapy-assimulo
+          auto-activate-base: false
+
+      - name: Install PharmaPy without pip solver resolution
+        shell: bash -el {0}
+        run: python -m pip install -e . --no-deps
+
+      - name: Run Assimulo-marked tests
+        shell: bash -el {0}
+        run: python -m pytest tests/ -v -m assimulo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,18 @@ name: CI
 on:
   push:
     branches:
-      - "**"
+      - master
   pull_request:
     branches:
       - "**"
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   core-tests:
@@ -17,10 +24,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -43,7 +50,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install system solver libraries
         run: |
@@ -51,13 +58,14 @@ jobs:
           sudo apt-get install -y gfortran liblapack-dev libblas-dev
 
       - name: Set up conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest
           use-mamba: true
           environment-file: environment.yml
           activate-environment: pharmapy-assimulo
-          auto-activate-base: false
+          auto-activate: false
+          conda-remove-defaults: true
 
       - name: Install PharmaPy without pip solver resolution
         shell: bash -el {0}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,10 @@
 include LICENSE.md
 include README.md
 include DEPENDENCIES.md
+include TESTING.md
 include requirements.txt
 include requirements-assimulo.txt
+include environment.yml
 include install_instructions.txt
 include InstallOnMac.sh
 include InstallOnWindows.bat

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,22 @@
+# Testing
+
+Run the core pytest slice without the optional Assimulo solver stack:
+
+```bash
+python -m pip install -e ".[test]"
+python -m pytest --collect-only
+python -m pytest tests/ -m "not assimulo"
+```
+
+Run the Assimulo-backed integration tests with conda-forge:
+
+```bash
+conda env create -f environment.yml
+conda activate pharmapy-assimulo
+python -m pip install -e . --no-deps
+python -m pytest tests/ -v -m assimulo
+```
+
+The GitHub Actions Assimulo job is intentionally informational at first. It
+uses `continue-on-error: true` so failures in the external solver stack do not
+block the core test job while the environment is stabilized.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: pharmapy-assimulo
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - assimulo=3.4.3
+  - numpy
+  - scipy
+  - matplotlib
+  - pandas
+  - pytest
+  - pip

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+from PharmaPy.Connections import topological_bfs
+from PharmaPy.Interpolation import local_newton_interpolation
+from PharmaPy.NameAnalysis import get_dict_states
+
+
+def test_topological_bfs_orders_linear_graph():
+    graph = {
+        "feed": ["reactor"],
+        "reactor": ["filter"],
+        "filter": [],
+    }
+
+    in_degree, path = topological_bfs(graph)
+
+    assert path == ["feed", "reactor", "filter"]
+    assert all(count == 0 for count in in_degree.values())
+
+
+def test_topological_bfs_leaves_cycle_with_incoming_edges():
+    graph = {
+        "a": ["b"],
+        "b": ["a"],
+    }
+
+    in_degree, path = topological_bfs(graph)
+
+    assert path == []
+    assert in_degree == {"a": 1, "b": 1}
+
+
+def test_get_dict_states_splits_composition_distribution_and_scalar():
+    states = np.array([
+        [1.0, 2.0, 10.0, 20.0, 30.0, 300.0],
+        [3.0, 4.0, 40.0, 50.0, 60.0, 310.0],
+    ])
+
+    result = get_dict_states(
+        ["mole_conc", "mu_n", "temp"],
+        num_species=2,
+        num_distr=3,
+        states=states,
+    )
+
+    np.testing.assert_allclose(result["mole_conc"], states[:, :2])
+    np.testing.assert_allclose(result["mu_n"], states[:, 2:5])
+    np.testing.assert_allclose(result["temp"], states[:, 5])
+
+
+def test_local_newton_interpolation_matches_quadratic():
+    time = np.array([0.0, 1.0, 2.0, 3.0])
+    values = time**2
+
+    interpolated = local_newton_interpolation(1.5, time, values)
+
+    assert interpolated == pytest.approx(2.25)


### PR DESCRIPTION
## Summary
- Add a non-blocking Assimulo integration job to the CI workflow.
- Use conda-forge through setup-miniconda and environment.yml to install the solver stack.
- Install PharmaPy with --no-deps inside the conda environment so pip does not try to rebuild Assimulo.
- Add TESTING.md with the local core and Assimulo test commands.

## Traceability
Closes #6.
Built on the merged #93 / #9 packaging and dependency-bounds work.
Refs SECQUOIA/PharmaPy#1, SECQUOIA/PharmaPy#2, CryPTSys/PharmaPy#106, and CryPTSys/PharmaPy#107.

## Verification
- actionlint .github/workflows/ci.yml
- pytest --collect-only -q
- pytest tests/ -m "not assimulo" -q -rs
- pytest tests/ -m assimulo -q -rs (local environment without Assimulo: 6 selected, 6 skipped)
- python -m build --sdist --no-isolation
- GitHub Actions CI pull_request run 28606044218: Core tests and Assimulo integration tests passed.

## Actions
GitHub Actions now runs both the core job and the informational Assimulo job. The Assimulo job remains marked continue-on-error: true until the conda solver stack is proven stable across follow-up runs.
