### PR TITLE
CI: narrow push trigger to master and bump to Node 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - "**"
+      - master
   pull_request:
     branches:
       - "**"
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary

Follow-ups to #91 (merged), both on `.github/workflows/ci.yml`:

- **Narrow the `push` trigger to `master`.** With #91 landed, `push` on `branches: ["**"]` mainly produced a duplicate run alongside the `pull_request` run on every branch push (the `concurrency` group is keyed on `github.ref`, which differs between `push` and `pull_request`, so it does not cancel that pair). Branch CI still runs via `pull_request`; this removes the redundant per-push run. Resolves the nonblocking thread deferred in #91.
- **Bump to Node 24 actions.** `actions/checkout@v4` -> `@v5` and `actions/setup-python@v5` -> `@v6`. Both new majors run natively on Node 24, clearing the "Node.js 20 is deprecated" annotation observed on the #91 merge run.

## Checks

- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text())"` -> `yaml ok`
- Verified `actions/checkout@v5` and `actions/setup-python@v6` tags exist.

## Traceability

Refs #91, #5.
