### PR TITLE
Add Commons and Connections unit coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,6 @@ dist/
 .pytest_cache/
 .ruff_cache/
 
-# Local agent configuration
-.claude/
-.codex/
-
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ dist/
 .pytest_cache/
 .ruff_cache/
 
+# Local agent configuration
+.claude/
+.codex/
+
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/tests/test_commons_helpers.py
+++ b/tests/test_commons_helpers.py
@@ -1,0 +1,106 @@
+import numpy as np
+import pytest
+
+from PharmaPy.Commons import (
+    flatten_states,
+    high_resolution_fvm,
+    unpack_discretized,
+    unpack_states,
+    upwind_fvm,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_unpack_states_splits_vector_state_by_declared_dimensions():
+    states = np.array([1.0, 2.0, 300.0, 4.0])
+
+    result = unpack_states(
+        states,
+        num_states=[2, 1, 1],
+        name_states=["mole_conc", "temp", "vol"],
+    )
+
+    np.testing.assert_allclose(result["mole_conc"], [1.0, 2.0])
+    assert result["temp"] == pytest.approx(300.0)
+    assert result["vol"] == pytest.approx(4.0)
+
+
+def test_unpack_states_splits_time_series_and_applies_state_map():
+    states = np.array([
+        [1.0, 2.0, 300.0, 4.0],
+        [5.0, 6.0, 310.0, 8.0],
+    ])
+
+    result = unpack_states(
+        states,
+        num_states=[2, 1, 1],
+        name_states=["mole_conc", "temp", "vol"],
+        state_map=[True, False, True],
+    )
+
+    assert list(result) == ["mole_conc", "vol"]
+    np.testing.assert_allclose(result["mole_conc"], states[:, :2])
+    np.testing.assert_allclose(result["vol"], [4.0, 8.0])
+
+
+def test_unpack_discretized_rebuilds_finite_volume_state_profiles():
+    states = np.array([
+        [1.0, 10.0, 100.0, 2.0, 20.0, 200.0],
+        [3.0, 30.0, 300.0, 4.0, 40.0, 400.0],
+    ])
+
+    result = unpack_discretized(
+        states,
+        num_states=[1, 2],
+        name_states=["temp", "mole_conc"],
+        indexes={"temp": None, "mole_conc": ["A", "B"]},
+    )
+
+    np.testing.assert_allclose(result["temp"], [[1.0, 2.0], [3.0, 4.0]])
+    np.testing.assert_allclose(
+        result["mole_conc"]["A"],
+        [[10.0, 20.0], [30.0, 40.0]],
+    )
+    np.testing.assert_allclose(
+        result["mole_conc"]["B"],
+        [[100.0, 200.0], [300.0, 400.0]],
+    )
+
+
+def test_flatten_states_merges_profiles_without_duplicate_boundaries():
+    segments = [
+        {
+            "time": np.array([0.0, 1.0]),
+            "states": np.array([[1.0, 10.0], [2.0, 20.0]]),
+        },
+        {
+            "time": np.array([1.0, 2.0, 3.0]),
+            "states": np.array([[2.0, 20.0], [3.0, 30.0], [4.0, 40.0]]),
+        },
+    ]
+
+    result = flatten_states(segments)
+
+    np.testing.assert_allclose(result["time"], [0.0, 1.0, 2.0, 3.0])
+    np.testing.assert_allclose(
+        result["states"],
+        [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]],
+    )
+
+
+def test_high_resolution_fvm_van_leer_flux_matches_hand_calculation():
+    state = np.array([1.0, 2.0, 4.0])
+
+    fluxes = high_resolution_fvm(state, boundary_cond=0.0)
+
+    np.testing.assert_allclose(fluxes, [0.0, 1.5, 8.0 / 3.0, 5.0])
+
+
+def test_upwind_fvm_returns_neighbor_differences_from_boundary():
+    state = np.array([1.0, 2.0, 4.0])
+
+    fluxes = upwind_fvm(state, boundary_cond=0.0)
+
+    np.testing.assert_allclose(fluxes, [1.0, 1.0, 2.0])

--- a/tests/test_connections_helpers.py
+++ b/tests/test_connections_helpers.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from PharmaPy.Connections import (
+    convert_str_flowsheet,
+    get_input_dict,
+    get_missing_field,
+    get_remaining_states,
+    interpolate_inputs,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_convert_str_flowsheet_builds_adjacency_map_from_sequence():
+    flowsheet = "Feed --> Reactor --> Filter"
+
+    result = convert_str_flowsheet(flowsheet)
+
+    assert result == {
+        "Feed": ["Reactor"],
+        "Reactor": ["Filter"],
+        "Filter": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("dim_state", "n_times", "expected"),
+    [
+        (1, 1, 0),
+        (3, 1, np.zeros(3)),
+        (1, 2, np.zeros(2)),
+        (2, 3, np.zeros((3, 2))),
+    ],
+)
+def test_get_missing_field_returns_zero_with_expected_shape(
+    dim_state,
+    n_times,
+    expected,
+):
+    result = get_missing_field(dim_state, n_times)
+
+    np.testing.assert_allclose(result, expected)
+
+
+def test_get_input_dict_splits_vector_input_by_state_dimensions():
+    input_data = np.array([1.0, 2.0, 300.0])
+    name_dict = {"Inlet": {"mole_conc": 2, "temp": 1}}
+
+    result = get_input_dict(input_data, name_dict)
+
+    np.testing.assert_allclose(result["Inlet"]["mole_conc"], [1.0, 2.0])
+    assert result["Inlet"]["temp"] == pytest.approx(300.0)
+
+
+def test_get_input_dict_splits_time_series_columns_by_state_dimensions():
+    input_data = np.array([
+        [1.0, 2.0, 300.0],
+        [3.0, 4.0, 310.0],
+    ])
+    name_dict = {"Inlet": {"mole_conc": 2, "temp": 1}}
+
+    result = get_input_dict(input_data, name_dict)
+
+    np.testing.assert_allclose(result["Inlet"]["mole_conc"], input_data[:, :2])
+    np.testing.assert_allclose(result["Inlet"]["temp"], [300.0, 310.0])
+
+
+def test_interpolate_inputs_evaluates_vector_times_without_solver_stack():
+    inlet_time = np.array([0.0, 1.0, 2.0])
+    inlet_values = np.array([
+        [0.0, 0.0],
+        [1.0, 10.0],
+        [2.0, 20.0],
+    ])
+
+    result = interpolate_inputs(
+        np.array([0.5, 1.5]),
+        inlet_time,
+        inlet_values,
+    )
+
+    np.testing.assert_allclose(result, [[0.5, 5.0], [1.5, 15.0]])
+
+
+def test_get_remaining_states_uses_stream_values_and_zero_defaults():
+    stream = SimpleNamespace(
+        mole_conc=np.array([1.0, 2.0]),
+        temp=300.0,
+        Solid=SimpleNamespace(mu_n=None),
+    )
+    state_dimensions = {
+        "Inlet": {"mole_conc": 2, "temp": 1, "mass": 1},
+        "Solid": {"mu_n": 3},
+    }
+    existing_inlets = {"Inlet": {"temp": 305.0}, "Solid": {}}
+
+    result = get_remaining_states(
+        state_dimensions,
+        stream,
+        existing_inlets,
+        time=np.array([0.0, 1.0]),
+    )
+
+    np.testing.assert_allclose(
+        result["Inlet"]["mole_conc"],
+        [[1.0, 2.0], [1.0, 2.0]],
+    )
+    np.testing.assert_allclose(result["Inlet"]["mass"], [0.0, 0.0])
+    np.testing.assert_allclose(result["Solid"]["mu_n"], np.zeros((2, 3)))


### PR DESCRIPTION
## Summary

- Add fast `@pytest.mark.unit` test files for `PharmaPy.Commons` and `PharmaPy.Connections` helper behavior.
- Cover state unpacking, discretized finite-volume state reconstruction, profile flattening, FVM flux helpers, flowsheet parsing, input splitting, missing-field defaults, interpolation, and remaining-state filling with hand-checkable NumPy fixtures.

Refs #7.

## Coverage Scope

This is one small Wave 2 test-only slice for issue #7. It does not close the full coverage roadmap or set the repository-wide coverage target; it adds fifteen fast Commons/Connections unit tests that run in the existing Assimulo-free lane.

## Tests

- `pytest tests/test_commons_helpers.py -q`
- `pytest tests/test_connections_helpers.py -q`
- `pytest tests/ -m "not assimulo" -q -rs`
- `pytest --collect-only -q -rs`
- `pytest tests/ -m unit -q -rs`
- `pytest -q -rs`

## Branch Hygiene

- Base branch: `master`
- Source branch: `test/issue-7-unit-coverage`
- Branch point: `origin/master` at `bff897f`
- Upstream status: `upstream/master` at `400e1e1` is included in the fork base.
- Stacked status: unstacked; no prerequisite PRs.
