### PR TITLE
fix: correct boundary off-by-one in local_newton_interpolation

### DIFF
--- a/PharmaPy/Interpolation.py
+++ b/PharmaPy/Interpolation.py
@@ -15,8 +15,8 @@ from scipy.special import comb
 def local_newton_interpolation(time, t_data, y_data, num_points=3):
     idx_time = np.argmin(abs(time - t_data))
 
-    idx_lower = max(0, idx_time - 1)
-    idx_upper = min(len(t_data) - 1, idx_lower + num_points)
+    idx_lower = max(0, min(idx_time - 1, len(t_data) - num_points))
+    idx_upper = idx_lower + num_points
 
     t_interp = t_data[idx_lower:idx_upper]
     y_interp = y_data[idx_lower:idx_upper]

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -56,3 +56,39 @@ def test_local_newton_interpolation_matches_quadratic():
     interpolated = local_newton_interpolation(1.5, time, values)
 
     assert interpolated == pytest.approx(2.25)
+
+
+def test_local_newton_interpolation_at_final_node_returns_exact_value():
+    """Regression test for #77: querying exactly at the last data node
+    used to collapse the interpolation window to a single point (the
+    second-to-last node), returning the wrong value at the boundary."""
+    time = np.linspace(0.0, 10.0, 11)
+    values = time**2
+
+    interpolated = local_newton_interpolation(10.0, time, values)
+
+    assert interpolated == pytest.approx(100.0)
+
+
+def test_local_newton_interpolation_just_inside_final_node():
+    """Query just inside the final node -- still within the affected
+    boundary window, but not exactly on the last data point."""
+    time = np.linspace(0.0, 10.0, 11)
+    values = time**2
+
+    interpolated = local_newton_interpolation(9.5, time, values)
+
+    assert interpolated == pytest.approx(90.25)
+
+
+def test_local_newton_interpolation_away_from_boundary_unaffected():
+    """Control case: a query comfortably away from the final node was
+    never affected by the boundary bug, so this should pass both before
+    and after the fix -- confirms the fix doesn't disturb interior
+    interpolation."""
+    time = np.linspace(0.0, 10.0, 11)
+    values = time**2
+
+    interpolated = local_newton_interpolation(5.0, time, values)
+
+    assert interpolated == pytest.approx(25.0)


### PR DESCRIPTION
Fixes #77. idx_upper was clamped at len(t_data) - 1 instead of
len(t_data), but slicing is exclusive of its end — so the
interpolation window could never reach the actual last data point.
Queries near the end of the horizon silently used a truncated window,
e.g. local_newton_interpolation(10.0, ...) on y=t**2 returned 81.0
instead of 100.0.

Fix: pull idx_lower back (not just clamp idx_upper) so the window
keeps its full num_points width whenever there's enough data, per the
formula suggested in the issue.

Added regression tests: exact boundary (last node), just inside it,
and a control case away from the boundary (passes both before and
after, confirming interior behavior is unchanged). Both boundary tests
failed with the exact reported wrong values before the fix.