### PR TITLE
Fix SimExec stream routing for graph successors

### DIFF
--- a/PharmaPy/SimExec.py
+++ b/PharmaPy/SimExec.py
@@ -155,7 +155,7 @@ class SimulationExec:
             # instance is already solved, pass data to connection
             elif isinstance(instance.outputs, dict):
                 count = self._transfer_to_neighbors(
-                    name, connections, count)
+                    name, connections, count, pick_units)
 
         self.time_processing = time_processing
 

--- a/PharmaPy/SimExec.py
+++ b/PharmaPy/SimExec.py
@@ -19,6 +19,7 @@ from PharmaPy.Commons import trapezoidal_rule, check_steady_state
 from PharmaPy.CheckModule import check_modeling_objects
 
 import time
+from typing import Optional, Sequence
 
 
 class SimulationExec:
@@ -46,7 +47,30 @@ class SimulationExec:
             raise PharmaPyNonImplementedError(
                 "Provided flowsheet contains recycle stream(s)")
 
-    def _transfer_to_neighbors(self, name, connections, count, pick_units=None):
+    def _transfer_to_neighbors(self, name: str, connections: dict, count: int,
+                               pick_units: Optional[Sequence[str]] = None) -> int:
+        """
+        Transfer output data from a unit operation to graph successors.
+
+        Parameters
+        ----------
+        name : str
+            Name of the source unit operation in the flowsheet graph.
+        connections : dict
+            Mapping used to store generated Connection objects. The mapping is
+            updated in place.
+        count : int
+            Counter used to build connection names.
+        pick_units : sequence of str, optional
+            Unit operation names selected for execution. Successors outside
+            this sequence are skipped when provided.
+
+        Returns
+        -------
+        count : int
+            Next available connection counter after transfers are created.
+
+        """
         for uo_next in self.graph[name]:
             if pick_units is not None and uo_next not in pick_units:
                 continue
@@ -66,6 +90,38 @@ class SimulationExec:
 
     def SolveFlowsheet(self, kwargs_run=None, pick_units=None, verbose=True,
                        steady_state_di=None, tolerances_ss=None, ss_time=0):
+        """
+        Solve unit operations and transfer stream data through the flowsheet.
+
+        The flowsheet is executed in topological order. Unit operations listed
+        in ``pick_units`` are solved before their output data are transferred
+        to selected graph successors. Units not selected in ``pick_units`` can
+        still transfer existing output data when already solved.
+
+        Parameters
+        ----------
+        kwargs_run : dict, optional
+            Keyword arguments passed to each unit operation ``solve_unit`` call,
+            keyed by unit operation name.
+        pick_units : sequence of str, optional
+            Unit operation names to solve. If omitted, all unit operations in
+            the execution order are solved.
+        verbose : bool, optional
+            If true, print progress messages for each solved unit operation.
+        steady_state_di : dict, optional
+            Steady-state event configuration keyed by unit operation name.
+        tolerances_ss : dict, optional
+            Reserved steady-state tolerance mapping.
+        ss_time : float, optional
+            Initial steady-state time horizon accumulator.
+
+        Returns
+        -------
+        None
+            Results are stored on ``time_processing``, ``result``, and
+            ``connections`` attributes.
+
+        """
 
         if kwargs_run is None:
             kwargs_run = {}

--- a/PharmaPy/SimExec.py
+++ b/PharmaPy/SimExec.py
@@ -46,6 +46,24 @@ class SimulationExec:
             raise PharmaPyNonImplementedError(
                 "Provided flowsheet contains recycle stream(s)")
 
+    def _transfer_to_neighbors(self, name, connections, count, pick_units=None):
+        for uo_next in self.graph[name]:
+            if pick_units is not None and uo_next not in pick_units:
+                continue
+
+            connection = Connection(
+                source_uo=getattr(self, name),
+                destination_uo=getattr(self, uo_next))
+
+            conn_name = 'CONN%i' % count
+            connections[conn_name] = connection
+
+            connection.transfer_data()
+
+            count += 1
+
+        return count
+
     def SolveFlowsheet(self, kwargs_run=None, pick_units=None, verbose=True,
                        steady_state_di=None, tolerances_ss=None, ss_time=0):
 
@@ -126,19 +144,8 @@ class SimulationExec:
                     print()
 
                 # Create connection object if needed
-                neighbors = self.graph[name]
-                if len(neighbors) > 0 and self.execution_names[ind + 1] in pick_units:
-                    uo_next = self.execution_names[ind + 1]
-                    connection = Connection(
-                        source_uo=getattr(self, name),
-                        destination_uo=getattr(self, uo_next))
-
-                    conn_name = 'CONN%i' % count
-                    connections[conn_name] = connection
-
-                    connection.transfer_data()
-
-                    count += 1
+                count = self._transfer_to_neighbors(
+                    name, connections, count, pick_units)
 
                 # Processing times
                 if hasattr(instance.result, 'time'):
@@ -147,17 +154,8 @@ class SimulationExec:
 
             # instance is already solved, pass data to connection
             elif isinstance(instance.outputs, dict):
-                connection = Connection(
-                    source_uo=getattr(self, name),
-                    destination_uo=getattr(self,
-                                           self.execution_names[ind + 1]))
-
-                conn_name = 'CONN%i' % count
-                connections[conn_name] = connection
-
-                connection.transfer_data()
-
-                count += 1
+                count = self._transfer_to_neighbors(
+                    name, connections, count)
 
         self.time_processing = time_processing
 

--- a/tests/test_simexec_routing.py
+++ b/tests/test_simexec_routing.py
@@ -1,0 +1,84 @@
+import os
+
+import numpy as np
+import pytest
+
+import PharmaPy.SimExec as se
+
+
+pytestmark = pytest.mark.unit
+
+PATH_PHYS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(se.__file__))),
+    "tests",
+    "Flowsheet",
+    "data",
+    "compound_database.json",
+)
+
+
+class _Result:
+    time = np.array([0.0, 1.0])
+
+
+class _StubUO:
+    __module__ = "PharmaPy.Containers"
+
+    def __init__(self, name):
+        self._name = name
+        self.outputs = {}
+        self.result = _Result()
+
+    def solve_unit(self, **kwargs):
+        pass
+
+    def flatten_states(self):
+        pass
+
+
+def _solve_and_record_connections(monkeypatch, graph):
+    created = []
+
+    class ConnRecorder:
+        def __init__(self, source_uo, destination_uo):
+            created.append((source_uo._name, destination_uo._name))
+
+        def transfer_data(self):
+            pass
+
+    monkeypatch.setattr(se, "check_modeling_objects", lambda *args, **kwargs: None)
+    monkeypatch.setattr(se, "SimulationResult", lambda *args, **kwargs: None)
+    monkeypatch.setattr(se, "Connection", ConnRecorder)
+
+    flst = se.SimulationExec(PATH_PHYS, flowsheet=graph)
+    for name in graph:
+        setattr(flst, name, _StubUO(name))
+
+    flst.SolveFlowsheet(verbose=False)
+
+    return created
+
+
+def _assert_connections_follow_graph(graph, created):
+    misrouted = [(source, dest) for source, dest in created
+                 if dest not in graph[source]]
+
+    assert not misrouted
+
+
+def test_stream_handoff_follows_graph_edges_not_execution_order(monkeypatch):
+    graph = {"A": ["C"], "B": ["C"], "C": ["D"], "D": []}
+
+    created = _solve_and_record_connections(monkeypatch, graph)
+
+    _assert_connections_follow_graph(graph, created)
+    assert set(created) == {("A", "C"), ("B", "C"), ("C", "D")}
+
+
+def test_stream_handoff_supports_fanout_to_multiple_successors(monkeypatch):
+    graph = {"A": ["B", "C"], "B": ["D"], "C": ["D"], "D": []}
+
+    created = _solve_and_record_connections(monkeypatch, graph)
+
+    _assert_connections_follow_graph(graph, created)
+    assert set(created) == {("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")}

--- a/tests/test_simexec_routing.py
+++ b/tests/test_simexec_routing.py
@@ -36,7 +36,7 @@ class _StubUO:
         pass
 
 
-def _solve_and_record_connections(monkeypatch, graph):
+def _solve_and_record_connections(monkeypatch, graph, pick_units=None):
     created = []
 
     class ConnRecorder:
@@ -54,7 +54,7 @@ def _solve_and_record_connections(monkeypatch, graph):
     for name in graph:
         setattr(flst, name, _StubUO(name))
 
-    flst.SolveFlowsheet(verbose=False)
+    flst.SolveFlowsheet(pick_units=pick_units, verbose=False)
 
     return created
 
@@ -82,3 +82,13 @@ def test_stream_handoff_supports_fanout_to_multiple_successors(monkeypatch):
 
     _assert_connections_follow_graph(graph, created)
     assert set(created) == {("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")}
+
+
+def test_already_solved_branch_honors_pick_units(monkeypatch):
+    graph = {"A": ["B", "C"], "B": ["D"], "C": ["D"], "D": []}
+
+    created = _solve_and_record_connections(
+        monkeypatch, graph, pick_units=["A", "C"])
+
+    _assert_connections_follow_graph(graph, created)
+    assert created == [("A", "C")]


### PR DESCRIPTION
## Summary

- Routes `SimulationExec` stream handoff through each actual graph successor in `self.graph[name]`.
- Reuses the same graph-neighbor transfer path for the already-solved branch.
- Adds fast unit coverage for fan-in and fan-out nonlinear flowsheets so topological execution order cannot be mistaken for connection topology.

Closes #19

## Tests

- `python3 -m pytest tests/test_simexec_routing.py -q`
- `python3 -m pytest tests/ -m "not assimulo"`
- Red-check: copied `tests/test_simexec_routing.py` into a detached `origin/master` worktree and confirmed both tests fail there with non-neighbor transfers (`B -> A`, `C -> B`).

`assimulo` is not installed in the active Python 3.10 environment, so the solver-backed `assimulo` tests were not run locally. The documented non-Assimulo slice selected 26 tests and deselected 6 `assimulo` tests.

## Branch Hygiene

- Base branch: `master`
- Source branch: `fix/issue-19-simexec-routing`
- Branch point: `origin/master` at `a80c706e4cd57036a9bedd65d5a44a6f450c3c04`
- Stacked status: not stacked
- Prerequisites: none
- Upstream status: `upstream/master` (`400e1e13ad4ecd3ba202d5fae8c70ec73bdf9c3e`) is an ancestor of `origin/master`
