### PR TITLE
Fix VaporPhase mass-basis latent heat weighting

### DIFF
--- a/PharmaPy/Phases.py
+++ b/PharmaPy/Phases.py
@@ -674,7 +674,9 @@ class VaporPhase(ThermoPhysicalManager):
         total_h : bool, optional
             If True, the total enthalpy is returned. If False, an array
             of individual enthalpy for each species is returned.
-            he default is True.
+            The default is True.
+        basis : {'mass', 'mole'}, optional
+            Basis for the returned enthalpy. The default is 'mass'.
 
         Returns
         -------
@@ -727,7 +729,8 @@ class VaporPhase(ThermoPhysicalManager):
 
         # Collect terms
         if total_h:
-            hVap = hSens + np.dot(deltaVap, mole_frac)
+            frac = mass_frac if basis == 'mass' else mole_frac
+            hVap = hSens + np.dot(deltaVap, frac)
 
         else:
             hVap = hSens + deltaVap

--- a/tests/test_phases_vapor_enthalpy.py
+++ b/tests/test_phases_vapor_enthalpy.py
@@ -1,0 +1,71 @@
+import json
+
+import numpy as np
+import pytest
+
+from PharmaPy.Phases import VaporPhase
+
+
+THERMO_TWO_SPECIES = {
+    "light": {
+        "mw": 18.0,
+        "t_crit": 650.0,
+        "rho_liq": 1000.0,
+        "cp_liq": [75.0],
+        "p_vap": [8.0, 1500.0, -40.0],
+        "delta_hvap": 40000.0,
+        "tref_hvap": 350.0,
+    },
+    "heavy": {
+        "mw": 100.0,
+        "t_crit": 700.0,
+        "rho_liq": 900.0,
+        "cp_liq": [150.0],
+        "p_vap": [8.0, 1800.0, -40.0],
+        "delta_hvap": 60000.0,
+        "tref_hvap": 350.0,
+    },
+}
+
+
+def test_vaporphase_mass_basis_weights_latent_heat_by_mass_fraction(tmp_path):
+    path = tmp_path / "thermo_two_species.json"
+    path.write_text(json.dumps(THERMO_TWO_SPECIES))
+
+    temp = 350.0
+    temp_ref = 298.15
+    mole_frac = np.array([0.5, 0.5])
+    phase = VaporPhase(
+        str(path),
+        temp=temp,
+        moles=1.0,
+        mole_frac=mole_frac,
+        check_input=False,
+    )
+
+    mw = np.array([18.0, 100.0])
+    cp_liq = np.array([75.0, 150.0])
+    delta_hvap = np.array([40000.0, 60000.0])
+    mass_frac = mole_frac * mw / np.dot(mole_frac, mw)
+
+    species_h_mole = cp_liq * (temp - temp_ref) + delta_hvap
+    expected_h_mole = np.dot(mole_frac, species_h_mole)
+
+    species_h_mass = species_h_mole * 1000.0 / mw
+    expected_h_mass = np.dot(mass_frac, species_h_mass)
+
+    h_mole = phase.getEnthalpy(temp=temp, basis="mole")
+    h_mass = phase.getEnthalpy(temp=temp, basis="mass")
+
+    assert h_mole == pytest.approx(expected_h_mole)
+    assert h_mass == pytest.approx(expected_h_mass)
+    assert h_mass == pytest.approx(h_mole * 1000.0 / phase.mw_av)
+
+    np.testing.assert_allclose(
+        phase.getEnthalpy(temp=temp, total_h=False, basis="mole"),
+        np.atleast_2d(species_h_mole),
+    )
+    np.testing.assert_allclose(
+        phase.getEnthalpy(temp=temp, total_h=False, basis="mass"),
+        np.atleast_2d(species_h_mass),
+    )


### PR DESCRIPTION
## Summary

- Fix `VaporPhase.getEnthalpy(basis="mass")` so the per-species J/kg latent heat term is weighted by mass fractions.
- Preserve the existing mole-basis weighting and the `total_h=False` per-species return path.
- Add a regression test with two species of very different molecular weights that verifies mass-basis/mole-basis consistency.

Closes #18

## Tests

- `pytest tests/test_phases_vapor_enthalpy.py`
- `pytest tests/ -m "not assimulo"`
- `pytest tests/ --collect-only -q`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check`

Assimulo-marked integration tests were not run locally because Assimulo is not installed in this environment; the CI workflow runs that marker group separately.

## Branch Hygiene

- Base branch: `master`
- Source branch point: `origin/master` at `1c3a046fceb5c4da8b5fdb6e8b254f657d6e3cc7`
- Upstream status: `origin/master` includes `upstream/master` at `400e1e13ad4ecd3ba202d5fae8c70ec73bdf9c3e`
- Stacked status: not stacked; no prerequisite PRs
- Note: an old remote branch named `fix-issue18-latent-heat-weighting` exists at an ancestor of current `origin/master` and has no PR; this PR uses a fresh focused branch.
