### PR TITLE
Fix semibatch reactor energy flow term

### DIFF
--- a/PharmaPy/Reactors.py
+++ b/PharmaPy/Reactors.py
@@ -1044,7 +1044,12 @@ class CSTR(_BaseReactor):
                                    total_h=False, basis='mole')
 
         h_in = (inlet_conc * h_inj).sum(axis=1) * 1000  # J/m**3
-        h_temp = (mole_conc * h_tempj).sum(axis=1) * 1000  # J/m**3
+
+        if 'vol' in self.states_uo:  # Semibatch: no outlet enthalpy stream
+            h_temp = (inlet_conc * h_tempj).sum(axis=1) * 1000  # J/m**3
+        else:
+            h_temp = (mole_conc * h_tempj).sum(axis=1) * 1000  # J/m**3
+
         flow_term = inlet_flow * (h_in - h_temp)  # W
 
         # Balance terms (W) - convert vol to L

--- a/tests/test_reactors_energy.py
+++ b/tests/test_reactors_energy.py
@@ -1,0 +1,129 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_INIT = REPO_ROOT / "PharmaPy" / "__init__.py"
+
+
+def _stub_assimulo_modules(monkeypatch):
+    """Let algebra-only reactor tests import without the optional solver."""
+    assimulo = ModuleType("assimulo")
+
+    solvers = ModuleType("assimulo.solvers")
+    solvers.CVode = object
+    solvers.LSODAR = object
+
+    problem = ModuleType("assimulo.problem")
+    problem.Explicit_Problem = object
+
+    monkeypatch.setitem(sys.modules, "assimulo", assimulo)
+    monkeypatch.setitem(sys.modules, "assimulo.solvers", solvers)
+    monkeypatch.setitem(sys.modules, "assimulo.problem", problem)
+
+
+def _prefer_source_package():
+    """Avoid importing the outer checkout package named PharmaPy."""
+    loaded = sys.modules.get("PharmaPy")
+    loaded_path = getattr(loaded, "__file__", None)
+    if loaded is not None and (
+            loaded_path is None or Path(loaded_path).resolve() != PACKAGE_INIT):
+        del sys.modules["PharmaPy"]
+
+    try:
+        sys.path.remove(str(REPO_ROOT))
+    except ValueError:
+        pass
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture
+def reactors(monkeypatch):
+    _prefer_source_package()
+
+    try:
+        import PharmaPy.Reactors as reactors_module
+    except ModuleNotFoundError as exc:
+        if exc.name != "assimulo":
+            raise
+        _stub_assimulo_modules(monkeypatch)
+
+        import PharmaPy.Reactors as reactors_module
+
+    return reactors_module
+
+
+class _StubLiquid:
+    def __init__(self, heat_capacities):
+        self.heat_capacities = np.asarray(heat_capacities, dtype=float)
+
+    def getCpPure(self, temp):
+        return None, self.heat_capacities
+
+    def getEnthalpy(self, temp, temp_ref, total_h=False, basis="mole"):
+        temp = np.atleast_1d(temp)
+        return self.heat_capacities[None, :] * (temp[:, None] - temp_ref)
+
+    def getHeatOfRxn(self, stoich, temp, mask, dh_ref, tref):
+        return np.zeros((1, 1))
+
+
+class _StubKinetics:
+    delta_hrxn = np.zeros(1)
+    stoich_matrix = np.zeros((1, 2))
+    tref_hrxn = 298.15
+
+    def get_rxn_rates(self, conc, temp, overall_rates=False, delta_hrxn=None):
+        return np.zeros((1, 1))
+
+
+def _configure_energy_balance_stubs(reactor):
+    liquid = _StubLiquid([100.0, 200.0])
+
+    reactor.mask_species = np.array([True, True])
+    reactor.Liquid_1 = liquid
+    reactor.Inlet = liquid
+    reactor._Kinetics = _StubKinetics()
+
+
+def _flow_term(reactor):
+    inputs = {
+        "Inlet": {
+            "vol_flow": 2.0,
+            "mole_conc": np.array([1.0, 0.0]),
+            "temp": 350.0,
+        }
+    }
+
+    heat_profile = reactor.energy_balances(
+        0.0,
+        np.array([0.0, 1.0]),
+        1.0,
+        350.0,
+        350.0,
+        inputs,
+        heat_prof=True,
+    )
+
+    return float(heat_profile[0, -1])
+
+
+def test_semibatch_flow_term_uses_inlet_composition_for_sensible_enthalpy(
+        reactors):
+    reactor = reactors.SemibatchReactor(vol_tank=1.0, isothermal=True)
+    _configure_energy_balance_stubs(reactor)
+
+    assert _flow_term(reactor) == pytest.approx(0.0)
+
+
+def test_cstr_flow_term_keeps_holdup_composition_for_outflow(reactors):
+    reactor = reactors.CSTR(isothermal=True)
+    _configure_energy_balance_stubs(reactor)
+
+    assert _flow_term(reactor) == pytest.approx(-10370000.0)


### PR DESCRIPTION
## Summary

- Correct the semibatch reactor convective energy term so sensible enthalpy at reactor temperature is weighted by inlet composition, matching the semibatch material accumulation balance with no outlet stream.
- Preserve CSTR behavior by keeping the holdup-composition outflow enthalpy for reactors without the semibatch `vol` state.
- Add algebra-level regression tests for the semibatch zero-driving-force case and the CSTR outflow guard.

Closes #87.

## Related Issues / Priority

- The Assimulo import workaround in the new algebra-level test is temporary and directly related to #10, which tracks lazy solver imports plus a solver interface / SciPy fallback.
- #10 should be prioritized before broad solver-adjacent test expansion or larger unit-operation refactors, because it removes the need for import-time stubs in core tests.
- #10 does not need to block this PR: this PR is a focused correctness fix for #87, keeps CSTR behavior pinned, and passes both core and Assimulo CI.
- Related roadmap context: #3 covers the broader CI / engineering baseline, #7 covers test expansion, and #8 covers packaging metadata cleanup.

## Tests

- `conda run -n pharmapy python -m pytest tests/test_reactors_energy.py -q`
- `conda run -n pharmapy python -m pytest --collect-only`
- `conda run -n pharmapy python -m pytest tests/ -m "not assimulo"`
- `timeout 180s conda run -n pharmapy python -m pytest tests/Flowsheet/flowsheet_tests.py::TestFlowsheets::test_SB_BC_FILT -q`
- `timeout 180s conda run -n pharmapy python -m pytest tests/ -m assimulo -q`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check --cached`

Notes: pytest emitted existing invalid-escape deprecation warnings in several modules and one existing runtime warning in the PFR flowsheet test.

## Branch Hygiene

- Base branch: `master`
- Source branch: `fix/issue-87-semibatch-energy`
- Branch point: `origin/master` at `1c3a046fceb5c4da8b5fdb6e8b254f657d6e3cc7`
- Upstream status: `origin/master` includes `upstream/master` at `400e1e13ad4ecd3ba202d5fae8c70ec73bdf9c3e`
- Stacked status: not stacked; no prerequisite PRs
