### PR TITLE
Fix drying saturation mass-rate conversion

### DIFF
--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -298,28 +298,18 @@ class Drying:
 
         # ----- Liquid phase
         dens_liq = self.rho_liq
-        
-        mw_volatiles = self.Liquid_1.mw[self.idx_volatiles] / 1000
-        dry_rate_mass = dry_rate[:, self.idx_volatiles] * mw_volatiles
-        sum_dry = dry_rate_mass.sum(axis=1)
-        # sum_dry[sum_dry < eps] = 0
+
+        # Convert molar drying rates to mass rates for the liquid balance (#20).
+        # Gas and energy balances still use molar rates pending #21 and #48.
+        mw_volatiles = self.Liquid_1.mw[self.idx_volatiles] / 1000  # [kg/mol]
+        dry_rate_mass = dry_rate[:, self.idx_volatiles] * mw_volatiles  # [kg/m**3/s]
+        sum_dry = dry_rate_mass.sum(axis=1)  # [kg/m**3/s]
 
         dsat_dt = -sum_dry / dens_liq / self.porosity
 
         dxliq_dt = -1 / satur* \
             (dry_rate_mass.T / dens_liq / self.porosity +
               x_liq.T * dsat_dt)
-            
-        # dxliq_dt = np.zeros([len(self.idx_volatiles), len(satur)])
-        
-        # for ind, val in enumerate(sum_dry):
-        #     if val == 0:
-        #         dxliq_dt[self.idx_volatiles, ind] = 0
-            
-        #     else:
-        #         dxliq_dt[self.idx_volatiles, ind] = -1 / satur[ind] * \
-        #     (dry_rate.T[self.idx_volatiles, ind] / dens_liq[ind] / self.porosity +
-        #       x_liq.T[self.idx_volatiles, ind] * dsat_dt[ind])
 
         # ----- Gas phase
         # Convective term

--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -299,13 +299,15 @@ class Drying:
         # ----- Liquid phase
         dens_liq = self.rho_liq
         
-        sum_dry = dry_rate.sum(axis=1)
+        mw_volatiles = self.Liquid_1.mw[self.idx_volatiles] / 1000
+        dry_rate_mass = dry_rate[:, self.idx_volatiles] * mw_volatiles
+        sum_dry = dry_rate_mass.sum(axis=1)
         # sum_dry[sum_dry < eps] = 0
-        
+
         dsat_dt = -sum_dry / dens_liq / self.porosity
-        
+
         dxliq_dt = -1 / satur* \
-            (dry_rate.T[self.idx_volatiles] / dens_liq / self.porosity +
+            (dry_rate_mass.T / dens_liq / self.porosity +
               x_liq.T * dsat_dt)
             
         # dxliq_dt = np.zeros([len(self.idx_volatiles), len(satur)])

--- a/tests/test_drying_model.py
+++ b/tests/test_drying_model.py
@@ -49,8 +49,7 @@ def test_material_balance_converts_molar_drying_rate_to_mass_for_saturation():
         inputs=inputs,
     )
 
-    mass_rate = (dry_rate[:, dryer.idx_volatiles] *
-                 dryer.Liquid_1.mw[dryer.idx_volatiles] / 1000).sum(axis=1)
+    mass_rate = np.array([0.22, 0.284])
     expected_dsat_dt = -mass_rate / dryer.rho_liq / dryer.porosity
 
     np.testing.assert_allclose(dsat_dt, expected_dsat_dt)

--- a/tests/test_drying_model.py
+++ b/tests/test_drying_model.py
@@ -1,8 +1,12 @@
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
+pytest.importorskip("assimulo")
 from PharmaPy.Drying_Model import Drying
+
+pytestmark = pytest.mark.assimulo
 
 
 def test_material_balance_converts_molar_drying_rate_to_mass_for_saturation():

--- a/tests/test_drying_model.py
+++ b/tests/test_drying_model.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from PharmaPy.Drying_Model import Drying
+
+
+def test_material_balance_converts_molar_drying_rate_to_mass_for_saturation():
+    dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer.idx_volatiles = np.array([0, 2])
+    dryer.porosity = 0.4
+    dryer.rho_liq = np.array([800.0, 900.0])
+    dryer.dz = np.ones(2)
+    dryer.Liquid_1 = SimpleNamespace(mw=np.array([18.0, 28.0, 46.0]))
+
+    satur = np.array([0.6, 0.8])
+    temp_gas = np.array([300.0, 305.0])
+    temp_sol = np.array([299.0, 304.0])
+    y_gas = np.array([
+        [0.02, 0.96, 0.02],
+        [0.03, 0.94, 0.03],
+    ])
+    x_liq = np.array([
+        [0.25, 0.75],
+        [0.40, 0.60],
+    ])
+    u_gas = np.zeros(2)
+    dens_gas = np.ones(2)
+    dry_rate = np.array([
+        [2.0, 0.0, 4.0],
+        [3.0, 0.0, 5.0],
+    ])
+    inputs = {"mass_frac": np.array([0.01, 0.98, 0.01])}
+
+    dsat_dt, _, _ = dryer.material_balance(
+        time=0.0,
+        satur=satur,
+        temp_gas=temp_gas,
+        temp_sol=temp_sol,
+        y_gas=y_gas,
+        x_liq=x_liq,
+        u_gas=u_gas,
+        dens_gas=dens_gas,
+        dry_rate=dry_rate,
+        inputs=inputs,
+    )
+
+    mass_rate = (dry_rate[:, dryer.idx_volatiles] *
+                 dryer.Liquid_1.mw[dryer.idx_volatiles] / 1000).sum(axis=1)
+    expected_dsat_dt = -mass_rate / dryer.rho_liq / dryer.porosity
+
+    np.testing.assert_allclose(dsat_dt, expected_dsat_dt)


### PR DESCRIPTION
Closes #20

## Summary
- Convert volatile drying rates from molar to mass basis before computing the liquid saturation derivative.
- Use the same mass-basis volatile rates in the liquid composition derivative term.
- Add a focused regression test for the saturation balance conversion.

## Tests
- `conda run -n pharmapy python -m pytest tests/test_drying_model.py -q`
- `conda run -n pharmapy python -m pytest tests/ -m "not assimulo" -q`
- `conda run -n pharmapy python -m pytest tests/ -m assimulo -q`
- `conda run -n pharmapy python -m pytest tests/ -q`

## Branch Hygiene
- Base branch: `master`
- Source branch point: `origin/master` at `1c3a046`
- Stacked status: standalone
- Prerequisite PRs: none
