### PR TITLE
Fix MSMPR scalar crystallization kinetics

### DIFF
--- a/PharmaPy/Kinetics.py
+++ b/PharmaPy/Kinetics.py
@@ -825,8 +825,17 @@ class CrystKinetics:
 
     def get_kinetics(self, conc, temp, kv_cry,
                      moments=None, nucl_sec_out=False):
+        """Evaluate crystallization kinetics for target concentration states.
 
-        conc_target = conc.T[self.target_idx]
+        Scalar concentrations are treated as the already-selected target
+        concentration, matching single-component steady-state solves.
+        """
+
+        conc_array = np.asarray(conc)
+        if conc_array.ndim == 0:
+            conc_target = conc_array.item()
+        else:
+            conc_target = conc_array.T[self.target_idx]
 
         # Supersaturation
         conc_sat = self.get_solubility(temp, conc)
@@ -838,6 +847,11 @@ class CrystKinetics:
         if self.sup_sat_type == 'ratio':
             sup_sat = sup_sat / conc_sat + 1
 
+        def is_default_secondary(name):
+            return (name == 'nucl_sec' and
+                    name not in self.custom_mechanisms and
+                    self.params_sec is None)
+
         par_p, par_s, par_g, par_d = self.params.values()
 
         if 'nucl_sec' in self.custom_mechanisms:
@@ -847,7 +861,12 @@ class CrystKinetics:
             args_sec = (kv_cry, self.reformulate_kin)
             par_sec = par_s
 
-        if isinstance(sup_sat, float):
+        if np.ndim(sup_sat) == 0:
+            sup_sat = np.asarray(sup_sat).item()
+            conc_sat = np.asarray(conc_sat).item()
+            if np.ndim(temp) == 0:
+                temp = np.asarray(temp).item()
+
             # print(sup_sat)
             args = [sup_sat, conc_sat, moments, temp, self.temp_ref]
             if sup_sat >= 0:
@@ -860,7 +879,9 @@ class CrystKinetics:
             mechs = {}
 
             for name in subset_mech:
-                if name in self.custom_mechanisms:
+                if is_default_secondary(name):
+                    mechs[name] = 0
+                elif name in self.custom_mechanisms:
                     args_concat = args + [self.params[name]]
                     mechs[name] = self.custom_mechanisms[name](*args_concat)
                 else:
@@ -907,7 +928,9 @@ class CrystKinetics:
                     temp_positive, self.temp_ref]
 
             for name in subset_mech:
-                if name in self.custom_mechanisms:
+                if is_default_secondary(name):
+                    continue
+                elif name in self.custom_mechanisms:
                     args_concat = args + [self.params[name]]
                     mechs[name][positive_map] = self.custom_mechanisms[name](*args_concat)
                 else:

--- a/PharmaPy/Kinetics.py
+++ b/PharmaPy/Kinetics.py
@@ -848,9 +848,15 @@ class CrystKinetics:
             sup_sat = sup_sat / conc_sat + 1
 
         def is_default_secondary(name):
-            return (name == 'nucl_sec' and
-                    name not in self.custom_mechanisms and
-                    self.params_sec is None)
+            """Return whether secondary nucleation is the inactive default."""
+            if name != 'nucl_sec' or name in self.custom_mechanisms:
+                return False
+
+            default = np.zeros_like(self.params['nucl_sec'], dtype=float)
+            if self.reformulate_kin:
+                default[0] = np.log(eps)
+
+            return np.allclose(self.params['nucl_sec'], default)
 
         par_p, par_s, par_g, par_d = self.params.values()
 

--- a/tests/test_cryst_kinetics.py
+++ b/tests/test_cryst_kinetics.py
@@ -81,6 +81,31 @@ def test_get_kinetics_preserves_vector_target_selection():
     np.testing.assert_allclose(dissol, [0.0, 0.0])
 
 
+def test_get_kinetics_uses_secondary_parameters_from_vector_update():
+    kin = _primary_growth_kinetics()
+    kin.set_params(
+        np.array([
+            1.0, 0.0, 1.0,
+            1.0, 0.0, 1.0, 1.0,
+            1.0, 0.0, 1.0,
+            0.0, 0.0, 0.0,
+        ])
+    )
+
+    conc = np.array([[0.5], [0.6]])
+    temp = np.array([298.15, 298.15])
+    moments = np.full((2, 4), 2.0)
+
+    prim, sec, growth, dissol = kin.get_kinetics(
+        conc, temp, 0.5, moments, nucl_sec_out=True
+    )
+
+    np.testing.assert_allclose(prim, [0.4, 0.5])
+    np.testing.assert_allclose(sec, [0.4, 0.5])
+    np.testing.assert_allclose(growth, [0.4, 0.5])
+    np.testing.assert_allclose(dissol, [0.0, 0.0])
+
+
 def test_msmpr_steady_state_accepts_scalar_seed(monkeypatch):
     MSMPR = _import_msmpr(monkeypatch)
 

--- a/tests/test_cryst_kinetics.py
+++ b/tests/test_cryst_kinetics.py
@@ -1,0 +1,117 @@
+import sys
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+from PharmaPy.Kinetics import CrystKinetics
+
+
+pytestmark = pytest.mark.unit
+
+
+def _primary_growth_kinetics():
+    kin = CrystKinetics(
+        coeff_solub=[0.1, 0.0, 0.0],
+        nucl_prim=[1.0, 0.0, 1.0],
+        growth=[1.0, 0.0, 1.0],
+        sup_sat_type="absolute",
+    )
+    kin.target_idx = 0
+    return kin
+
+
+def _stub_assimulo_modules(monkeypatch):
+    assimulo = ModuleType("assimulo")
+
+    solvers = ModuleType("assimulo.solvers")
+    solvers.CVode = object
+
+    problem = ModuleType("assimulo.problem")
+    problem.Explicit_Problem = object
+
+    exception = ModuleType("assimulo.exception")
+    exception.TerminateSimulation = Exception
+
+    monkeypatch.setitem(sys.modules, "assimulo", assimulo)
+    monkeypatch.setitem(sys.modules, "assimulo.solvers", solvers)
+    monkeypatch.setitem(sys.modules, "assimulo.problem", problem)
+    monkeypatch.setitem(sys.modules, "assimulo.exception", exception)
+
+
+def _import_msmpr(monkeypatch):
+    try:
+        from PharmaPy.Crystallizers import MSMPR
+    except ModuleNotFoundError as exc:
+        if exc.name != "assimulo":
+            raise
+        _stub_assimulo_modules(monkeypatch)
+
+        from PharmaPy.Crystallizers import MSMPR
+
+    return MSMPR
+
+
+@pytest.mark.parametrize("conc", [0.5, np.array(0.5)])
+def test_get_kinetics_accepts_scalar_target_concentration(conc):
+    kin = _primary_growth_kinetics()
+
+    nucl, growth, dissol = kin.get_kinetics(conc, 298.15, 0.5)
+
+    assert np.ndim(nucl) == 0
+    assert np.ndim(growth) == 0
+    assert np.ndim(dissol) == 0
+    assert nucl == pytest.approx(0.4)
+    assert growth == pytest.approx(0.4)
+    assert dissol == pytest.approx(0.0)
+
+
+def test_get_kinetics_preserves_vector_target_selection():
+    kin = _primary_growth_kinetics()
+    kin.target_idx = 1
+
+    conc = np.array([[9.0, 0.5], [8.0, 0.6]])
+    temp = np.array([298.15, 298.15])
+    moments = np.zeros((2, 4))
+
+    nucl, growth, dissol = kin.get_kinetics(conc, temp, 0.5, moments)
+
+    np.testing.assert_allclose(nucl, [0.4, 0.5])
+    np.testing.assert_allclose(growth, [0.4, 0.5])
+    np.testing.assert_allclose(dissol, [0.0, 0.0])
+
+
+def test_msmpr_steady_state_accepts_scalar_seed(monkeypatch):
+    MSMPR = _import_msmpr(monkeypatch)
+
+    crystallizer = MSMPR.__new__(MSMPR)
+    crystallizer.vol_slurry = 1.0
+    crystallizer.target_ind = 0
+    crystallizer._Kinetics = _primary_growth_kinetics()
+
+    class Solid:
+        x_distrib = np.array([0.0, 1.0])
+        kv = 0.0
+
+        def getDensity(self, temp):
+            return 1.0
+
+    class Liquid:
+        mass_frac = np.array([0.5])
+
+    class Inlet:
+        vol_flow = 1.0
+        Liquid_1 = Liquid()
+
+    crystallizer.Solid_1 = Solid()
+    crystallizer._Inlet = Inlet()
+
+    x_vec, f_convg, w_convg, info, final_fn = crystallizer.solve_steady_state(
+        0.3, 298.15
+    )
+
+    np.testing.assert_allclose(x_vec, [0.0, 1.0])
+    np.testing.assert_allclose(f_convg, [1.0, np.exp(-2.5)])
+    assert w_convg == pytest.approx(0.5)
+    assert info.converged
+    assert final_fn == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

- Allow `CrystKinetics.get_kinetics` to accept scalar target concentrations from single-component steady-state solves while preserving vector target selection.
- Treat omitted default secondary nucleation parameters as zero so primary/growth-only scalar kinetics do not require moment inputs.
- Add regressions for Python float and NumPy 0-D scalar inputs, vector target selection, and the `MSMPR.solve_steady_state` scalar seed path.

Closes #61

## Tests

- `conda run -n pharmapy python -m pytest tests/test_cryst_kinetics.py -q`
- `conda run -n pharmapy python -m pytest --collect-only`
- `conda run -n pharmapy python -m pytest tests/ -m "not assimulo"`
- `timeout 180s conda run -n pharmapy python -m pytest tests/ -m assimulo -q`
- `conda run -n pharmapy python -m pytest tests/ -q`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check`

Notes: pytest reports existing invalid-escape deprecation warnings in several modules and one existing runtime warning in the PFR flowsheet test.

## Branch Hygiene

- Base branch: `master`
- Source branch: `fix/issue-61-msmpr-scalar-kinetics`
- Source branch point: `origin/master` at `1c3a046fceb5c4da8b5fdb6e8b254f657d6e3cc7`
- Upstream status: `origin/master` includes `upstream/master` at `400e1e13ad4ecd3ba202d5fae8c70ec73bdf9c3e`
- Stacked status: standalone
- Prerequisite PRs: none
