### PR TITLE
Fix distillation steady-state result retrieval

### DIFF
--- a/PharmaPy/Distillation.py
+++ b/PharmaPy/Distillation.py
@@ -510,7 +510,6 @@ class DistillationColumn(_BaseDistillation):
             self.calc_plates(**result['material_balances'],
                              reflux=result['reflux'],
                              num_plates=result['num_plates'])
-            self.retrieve_results()
 
         return result
 

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -1,0 +1,57 @@
+import pytest
+
+pytest.importorskip("assimulo")
+from PharmaPy.Distillation import DistillationColumn
+
+
+pytestmark = [pytest.mark.assimulo, pytest.mark.unit]
+
+
+def test_steady_state_solve_uses_calc_plates_results(monkeypatch):
+    column = DistillationColumn(
+        pres=101325,
+        q_feed=1.0,
+        LK="ethanol",
+        HK="water",
+        perc_LK=95.0,
+        perc_HK=5.0,
+    )
+    material_balances = {
+        "x_dist": [0.95, 0.05],
+        "x_bottom": [0.05, 0.95],
+        "dist_flow": 1.0,
+        "bottom_flow": 2.0,
+    }
+    expected = {
+        "material_balances": material_balances,
+        "min_reflux": 1.2,
+        "num_min": 4,
+        "reflux": 1.8,
+        "num_plates": 7,
+    }
+    calls = []
+
+    def fake_calculate_heuristics():
+        return expected
+
+    def fake_calc_plates(**kwargs):
+        calls.append(kwargs)
+
+    def fail_retrieve_results(*args, **kwargs):
+        raise AssertionError("solve_unit should not retrieve results twice")
+
+    monkeypatch.setattr(column, "calculate_heuristics", fake_calculate_heuristics)
+    monkeypatch.setattr(column, "calc_plates", fake_calc_plates)
+    monkeypatch.setattr(column, "retrieve_results", fail_retrieve_results)
+
+    result = column.solve_unit(solve_ss=True)
+
+    assert result == expected
+    assert calls == [{
+        "x_dist": [0.95, 0.05],
+        "x_bottom": [0.05, 0.95],
+        "dist_flow": 1.0,
+        "bottom_flow": 2.0,
+        "reflux": 1.8,
+        "num_plates": 7,
+    }]


### PR DESCRIPTION
## Summary

- remove the redundant no-argument `retrieve_results()` call from `DistillationColumn.solve_unit(solve_ss=True)`
- add a regression test proving steady-state solve delegates result retrieval through `calc_plates` without calling `retrieve_results` a second time

Closes #49

## Tests

- `/home/mlaljee/miniforge3/envs/pharmapy/bin/python -m pytest tests/test_distillation.py -q`
- `/home/mlaljee/miniforge3/envs/pharmapy/bin/python -m pytest tests -m unit -q`

## Branch Hygiene

- Base branch: `master`
- Source branch point: `4098d776613ecfab3d65e244a027cf58c3fe3c4a`
- Stacked status: standalone
- Prerequisite PRs: none
