### PR TITLE
Fix crystallizer energy balance units and jacket paths

### DIFF
--- a/PharmaPy/Crystallizers.py
+++ b/PharmaPy/Crystallizers.py
@@ -1520,7 +1520,7 @@ class BatchCryst(_BaseCryst):
 
         dmaterial_dt = np.concatenate((ddistr_dt, dliq_dt))
 
-        return dmaterial_dt, transf
+        return dmaterial_dt, transf  # transf [kg/s]
 
     def energy_balances(self, time, params, cryst_rate, u_inputs, rhos,
                         mu_n, distrib, mass_conc, temp, temp_ht, vol,
@@ -1546,7 +1546,7 @@ class BatchCryst(_BaseCryst):
         height_liq = vol / (np.pi/4 * self.diam_tank**2)
         area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # m**2
 
-        source_term = dh_cryst*cryst_rate
+        source_term = dh_cryst*cryst_rate  # [J/s], cryst_rate [kg/s]
 
         if self.adiabatic:
             ht_term = 0
@@ -1564,8 +1564,8 @@ class BatchCryst(_BaseCryst):
 
             if temp_ht is not None:
                 ht_dict = self.Utility.get_inputs(time)
-                tht_in = ht_dict['temp_in']
-                flow_ht = ht_dict['vol_flow']
+                tht_in = ht_dict['temp_in']  # [K], Utility inlet temperature
+                flow_ht = ht_dict['vol_flow']  # [m**3/s]
 
                 cp_ht = 4180  # J/kg/K
                 rho_ht = 1000
@@ -1845,7 +1845,7 @@ class MSMPR(_BaseCryst):
 
         dmaterial_dt = np.concatenate((ddistr_dt, dcomp_dt))
 
-        return dmaterial_dt, transf
+        return dmaterial_dt, transf  # transf [kg/m**3/s]
 
     def energy_balances(self, time, params, cryst_rate, u_inputs, rhos, mu_n,
                         distrib, mass_conc, temp, temp_ht, vol,
@@ -1872,10 +1872,10 @@ class MSMPR(_BaseCryst):
 
         # Energy terms (W)
         flow_term = input_flow * (h_in - h_sp)
-        source_term = dh_cryst*cryst_rate * vol
+        source_term = dh_cryst*cryst_rate * vol  # [J/s], cryst_rate [kg/m**3/s]
 
         if self.adiabatic:
-            ht_term = 0
+            ht_term = 0  # [J/s]
         elif 'temp' in self.controls.keys():
             ht_term = capacitance * vol  # return capacitance
         elif 'temp' in self.states_uo:
@@ -1885,20 +1885,20 @@ class MSMPR(_BaseCryst):
             return heat_components
         else:
             # Balance inside the tank
-            dtemp_dt = (flow_term - source_term - ht_term) / vol / capacitance
+            dtemp_dt = (flow_term - source_term - ht_term) / vol / capacitance  # [K/s]
 
             if self.adiabatic or temp_ht is None:
                 return dtemp_dt
 
             # Balance in the jacket
             ht_media = self.Utility.get_inputs(time)
-            flow_ht = ht_media['vol_flow']
-            tht_in = ht_media['temp_in']
+            flow_ht = ht_media['vol_flow']  # [m**3/s]
+            tht_in = ht_media['temp_in']  # [K], Utility inlet temperature
 
-            cp_ht = self.Utility.cp
-            rho_ht = self.Utility.rho
+            cp_ht = self.Utility.cp  # [J/kg/K]
+            rho_ht = self.Utility.rho  # [kg/m**3]
 
-            vol_ht = self.vol_tank*0.14  # m**3
+            vol_ht = self.vol_tank*0.14  # [m**3]
 
             dtht_dt = flow_ht / vol_ht * (tht_in - temp_ht) - \
                 self.u_ht*area_ht*(temp_ht - temp) / rho_ht/vol_ht/cp_ht
@@ -2164,7 +2164,7 @@ class SemibatchCryst(MSMPR):
 
         dmaterial_dt = np.concatenate((ddistr_dt, dliq_dt))
 
-        return dmaterial_dt, transf
+        return dmaterial_dt, transf  # transf [kg/s]
 
     def energy_balances(self, time, params, cryst_rate, u_inputs, rhos,
                         distrib, mass_conc, temp, temp_ht, vol, mu_n, h_in):
@@ -2199,7 +2199,7 @@ class SemibatchCryst(MSMPR):
         accum_term = dmass_dt * h_sp/dens_slurry
         flow_term = input_flow * h_in
 
-        source_term = dh_cryst * cryst_rate
+        source_term = dh_cryst * cryst_rate  # [J/s], cryst_rate [kg/s]
 
         height_liq = vol / (np.pi/4 * self.diam_tank**2)
         area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # m**2
@@ -2211,13 +2211,11 @@ class SemibatchCryst(MSMPR):
 
         # Balance inside the tank
         dtemp_dt = (flow_term - source_term - ht_term - accum_term) / \
-            capacitance / vol
-
-        # print(dtemp_dt)
+            capacitance / vol  # [K/s]
 
         if temp_ht is not None:
             ht_media = self.Utility.get_inputs(time)
-            tht_in = ht_media['temp_in']  # [K]
+            tht_in = ht_media['temp_in']  # [K], Utility inlet temperature
             flow_ht = ht_media['vol_flow']  # [m**3/s]
             cp_ht = self.Utility.cp  # [J/kg/K]
             rho_ht = self.Utility.rho  # [kg/m**3]

--- a/PharmaPy/Crystallizers.py
+++ b/PharmaPy/Crystallizers.py
@@ -586,11 +586,12 @@ class _BaseCryst:
 
                 h_in = self.Inlet.getEnthalpy(inlet_temp, phis_in, rhos_in)
             else:
-                rho_liq_in = self.Inlet.getDensity(temp=inlet_temp)
+                rho_liq_in = self.Inlet.getDensity(temp=inlet_temp)  # [kg/m**3]
                 rho_sol_in = None
 
-                rhos_in = np.array([rho_liq_in, rho_sol_in])
-                h_in = self.Inlet.getEnthalpy(temp=inlet_temp)
+                rhos_in = np.array([rho_liq_in, rho_sol_in])  # [kg/m**3]
+                h_in_mass = self.Inlet.getEnthalpy(temp=inlet_temp)  # [J/kg]
+                h_in = h_in_mass * rho_liq_in  # [J/kg]*[kg/m**3] -> [J/m**3]
 
                 phis_in = [1, 0]
 
@@ -1808,7 +1809,7 @@ class MSMPR(_BaseCryst):
 
         rho_sol = rhos[0][1]
 
-        input_flow = u_inputs['Inlet']['vol_flow']
+        input_flow = u_inputs['Inlet']['vol_flow']  # [m**3/s]
 
         input_conc = u_inputs['Liquid_1']['mass_conc']
 
@@ -1852,50 +1853,55 @@ class MSMPR(_BaseCryst):
 
         rho_susp, rho_in = rhos
 
-        input_flow = u_inputs['Inlet']['vol_flow']
+        input_flow = u_inputs['Inlet']['vol_flow']  # [m**3/s]
 
         # Thermodynamic properties (basis: slurry volume)
-        phi_liq = 1 - self.Solid_1.kv * mu_n[3]
+        phi_liq = 1 - self.Solid_1.kv * mu_n[3]  # [-]
 
         phis = [phi_liq, 1 - phi_liq]
-        h_sp = self.Slurry.getEnthalpy(temp, phis, rho_susp)
-        capacitance = self.Slurry.getCp(temp, phis, rho_susp)  # J/m**3/K
+        h_sp = self.Slurry.getEnthalpy(temp, phis, rho_susp)  # [J/m**3]
+        capacitance = self.Slurry.getCp(temp, phis, rho_susp)  # [J/m**3/K]
 
         # Renaming
-        dh_cryst = -1.46e4  # J/kg  # TODO: read this from json file
+        dh_cryst = -1.46e4  # [J/kg]  # TODO: read this from json file
         # dh_cryst = -self.Liquid_1.delta_fus[self.target_ind] / \
         #     self.Liquid_1.mw[self.target_ind] * 1000  # J/kg
 
-        height_liq = vol / (np.pi/4 * self.diam_tank**2)
-        area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # m**2
+        height_liq = vol / (np.pi/4 * self.diam_tank**2)  # [m]
+        area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # [m**2]
 
-        # Energy terms (W)
-        flow_term = input_flow * (h_in - h_sp)
-        source_term = dh_cryst*cryst_rate * vol
+        # Energy terms
+        flow_term = input_flow * (h_in - h_sp)  # [J/s]
+        source_term = dh_cryst*cryst_rate * vol  # [J/s]
 
-        if 'temp' in self.controls.keys():
-            ht_term = capacitance * vol  # return capacitance
+        if self.adiabatic:
+            ht_term = 0  # [J/s]
+        elif 'temp' in self.controls.keys():
+            ht_term = capacitance * vol  # [J/K]
         elif 'temp' in self.states_uo:
-            ht_term = self.u_ht*area_ht*(temp - temp_ht)
+            ht_term = self.u_ht*area_ht*(temp - temp_ht)  # [J/s]
         if heat_prof:
             heat_components = np.hstack([source_term, ht_term, flow_term])
             return heat_components
         else:
             # Balance inside the tank
-            dtemp_dt = (flow_term - source_term - ht_term) / vol / capacitance
+            dtemp_dt = (flow_term - source_term - ht_term) / vol / capacitance  # [K/s]
+
+            if self.adiabatic or temp_ht is None:
+                return dtemp_dt
 
             # Balance in the jacket
             ht_media = self.Utility.get_inputs(time)
-            flow_ht = ht_media['vol_flow']
-            tht_in = ht_media['temp_in']
+            flow_ht = ht_media['vol_flow']  # [m**3/s]
+            tht_in = ht_media['temp_in']  # [K]
 
-            cp_ht = self.Utility.cp
-            rho_ht = self.Utility.rho
+            cp_ht = self.Utility.cp  # [J/kg/K]
+            rho_ht = self.Utility.rho  # [kg/m**3]
 
-            vol_ht = self.vol_tank*0.14  # m**3
+            vol_ht = self.vol_tank*0.14  # [m**3]
 
             dtht_dt = flow_ht / vol_ht * (tht_in - temp_ht) - \
-                self.u_ht*area_ht*(temp_ht - temp) / rho_ht/vol_ht/cp_ht
+                self.u_ht*area_ht*(temp_ht - temp) / rho_ht/vol_ht/cp_ht  # [K/s]
 
             return dtemp_dt, dtht_dt
 
@@ -2112,7 +2118,7 @@ class SemibatchCryst(MSMPR):
         rho_in_liq, _ = rho_in
 
         input_flow = u_inputs['Inlet']['vol_flow']
-        input_flow = np.max([eps, input_flow])
+        input_flow = np.max([eps, input_flow])  # [m**3/s]
 
         # TODO: generalize dictionary iteration ('Inlet', 'Liquid_1', ...)?
         input_distrib = u_inputs['Inlet']['distrib'] * self.scale
@@ -2166,58 +2172,59 @@ class SemibatchCryst(MSMPR):
         rho_susp, rho_in = rhos
 
         # Input properties
-        input_flow = u_inputs['Inlet']['vol_flow']
-        input_flow = np.max([eps, input_flow])
+        input_flow = u_inputs['Inlet']['vol_flow']  # [m**3/s]
+        input_flow = np.max([eps, input_flow])  # [m**3/s]
 
-        vol_solid = mu_n[3] * self.Solid_1.kv  # mu_3 is total, not by volume
-        vol_total = vol + vol_solid
+        vol_solid = mu_n[3] * self.Solid_1.kv  # [m**3]
+        vol_total = vol + vol_solid  # [m**3]
 
-        phi = vol / vol_total
+        phi = vol / vol_total  # [-]
         phis = [phi, 1 - phi]
-        dens_slurry = np.dot(rho_susp, phis)
+        dens_slurry = np.dot(rho_susp, phis)  # [kg/m**3]
 
         # Suspension properties
         capacitance = self.Slurry.getCp(temp, phis, rho_susp,
-                                        times_vliq=True)
-        h_sp = self.Slurry.getEnthalpy(temp, phis, rho_susp)
+                                        times_vliq=True)  # [J/m**3/K]
+        h_sp = self.Slurry.getEnthalpy(temp, phis, rho_susp)  # [J/m**3]
 
         # Renaming
-        dh_cryst = -1.46e4  # J/kg
+        dh_cryst = -1.46e4  # [J/kg]
         # dh_cryst = -self.Liquid_1.delta_fus[self.target_ind] / \
         #     self.Liquid_1.mw[self.target_ind] * 1000  # J/kg
 
         # Terms
-        dens_in_liq = rho_in[0]
-        dmass_dt = input_flow * dens_in_liq
+        dens_in_liq = rho_in[0]  # [kg/m**3]
+        dmass_dt = input_flow * dens_in_liq  # [kg/s]
 
-        accum_term = dmass_dt * h_sp/dens_slurry
-        flow_term = input_flow * h_in
+        accum_term = dmass_dt * h_sp/dens_slurry  # [J/s]
+        flow_term = input_flow * h_in  # [J/s]
 
-        source_term = dh_cryst * cryst_rate
+        source_term = dh_cryst * cryst_rate  # [J/s]
 
-        height_liq = vol / (np.pi/4 * self.diam_tank**2)
-        area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # m**2
+        height_liq = vol / (np.pi/4 * self.diam_tank**2)  # [m]
+        area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # [m**2]
 
         if self.adiabatic:
-            ht_term = 0
+            ht_term = 0  # [J/s]
         else:
-            ht_term = self.u_ht*area_ht*(temp - temp_ht)
+            ht_term = self.u_ht*area_ht*(temp - temp_ht)  # [J/s]
 
         # Balance inside the tank
         dtemp_dt = (flow_term - source_term - ht_term - accum_term) / \
-            capacitance / vol
+            capacitance / vol  # [K/s]
 
         # print(dtemp_dt)
 
         if temp_ht is not None:
-            tht_in = self.temp_ht_in  # degC
-            flow_ht = self.flow_ht
-            cp_ht = 4180  # J/kg/K
-            rho_ht = 1000
-            vol_ht = self.vol_tank*0.14  # m**3
+            ht_media = self.Utility.get_inputs(time)
+            tht_in = ht_media['temp_in']  # [K]
+            flow_ht = ht_media['vol_flow']  # [m**3/s]
+            cp_ht = self.Utility.cp  # [J/kg/K]
+            rho_ht = self.Utility.rho  # [kg/m**3]
+            vol_ht = self.vol_tank*0.14  # [m**3]
 
             dtht_dt = flow_ht / vol_ht * (tht_in - temp_ht) - \
-                self.u_ht*area_ht*(temp_ht - temp) / rho_ht/vol_ht/cp_ht
+                self.u_ht*area_ht*(temp_ht - temp) / rho_ht/vol_ht/cp_ht  # [K/s]
 
             return dtemp_dt, dtht_dt
 

--- a/PharmaPy/Crystallizers.py
+++ b/PharmaPy/Crystallizers.py
@@ -586,10 +586,10 @@ class _BaseCryst:
 
                 h_in = self.Inlet.getEnthalpy(inlet_temp, phis_in, rhos_in)
             else:
-                rho_liq_in = self.Inlet.getDensity(temp=inlet_temp)  # [kg/m**3]
+                rho_liq_in = self.Inlet.getDensity(temp=inlet_temp)
                 rho_sol_in = None
 
-                rhos_in = np.array([rho_liq_in, rho_sol_in])  # [kg/m**3]
+                rhos_in = np.array([rho_liq_in, rho_sol_in])
                 h_in_mass = self.Inlet.getEnthalpy(temp=inlet_temp)  # [J/kg]
                 h_in = h_in_mass * rho_liq_in  # [J/kg]*[kg/m**3] -> [J/m**3]
 
@@ -1809,7 +1809,7 @@ class MSMPR(_BaseCryst):
 
         rho_sol = rhos[0][1]
 
-        input_flow = u_inputs['Inlet']['vol_flow']  # [m**3/s]
+        input_flow = u_inputs['Inlet']['vol_flow']
 
         input_conc = u_inputs['Liquid_1']['mass_conc']
 
@@ -1853,55 +1853,55 @@ class MSMPR(_BaseCryst):
 
         rho_susp, rho_in = rhos
 
-        input_flow = u_inputs['Inlet']['vol_flow']  # [m**3/s]
+        input_flow = u_inputs['Inlet']['vol_flow']
 
         # Thermodynamic properties (basis: slurry volume)
-        phi_liq = 1 - self.Solid_1.kv * mu_n[3]  # [-]
+        phi_liq = 1 - self.Solid_1.kv * mu_n[3]
 
         phis = [phi_liq, 1 - phi_liq]
-        h_sp = self.Slurry.getEnthalpy(temp, phis, rho_susp)  # [J/m**3]
-        capacitance = self.Slurry.getCp(temp, phis, rho_susp)  # [J/m**3/K]
+        h_sp = self.Slurry.getEnthalpy(temp, phis, rho_susp)
+        capacitance = self.Slurry.getCp(temp, phis, rho_susp)  # J/m**3/K
 
         # Renaming
-        dh_cryst = -1.46e4  # [J/kg]  # TODO: read this from json file
+        dh_cryst = -1.46e4  # J/kg  # TODO: read this from json file
         # dh_cryst = -self.Liquid_1.delta_fus[self.target_ind] / \
         #     self.Liquid_1.mw[self.target_ind] * 1000  # J/kg
 
-        height_liq = vol / (np.pi/4 * self.diam_tank**2)  # [m]
-        area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # [m**2]
+        height_liq = vol / (np.pi/4 * self.diam_tank**2)
+        area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # m**2
 
-        # Energy terms
-        flow_term = input_flow * (h_in - h_sp)  # [J/s]
-        source_term = dh_cryst*cryst_rate * vol  # [J/s]
+        # Energy terms (W)
+        flow_term = input_flow * (h_in - h_sp)
+        source_term = dh_cryst*cryst_rate * vol
 
         if self.adiabatic:
-            ht_term = 0  # [J/s]
+            ht_term = 0
         elif 'temp' in self.controls.keys():
-            ht_term = capacitance * vol  # [J/K]
+            ht_term = capacitance * vol  # return capacitance
         elif 'temp' in self.states_uo:
-            ht_term = self.u_ht*area_ht*(temp - temp_ht)  # [J/s]
+            ht_term = self.u_ht*area_ht*(temp - temp_ht)
         if heat_prof:
             heat_components = np.hstack([source_term, ht_term, flow_term])
             return heat_components
         else:
             # Balance inside the tank
-            dtemp_dt = (flow_term - source_term - ht_term) / vol / capacitance  # [K/s]
+            dtemp_dt = (flow_term - source_term - ht_term) / vol / capacitance
 
             if self.adiabatic or temp_ht is None:
                 return dtemp_dt
 
             # Balance in the jacket
             ht_media = self.Utility.get_inputs(time)
-            flow_ht = ht_media['vol_flow']  # [m**3/s]
-            tht_in = ht_media['temp_in']  # [K]
+            flow_ht = ht_media['vol_flow']
+            tht_in = ht_media['temp_in']
 
-            cp_ht = self.Utility.cp  # [J/kg/K]
-            rho_ht = self.Utility.rho  # [kg/m**3]
+            cp_ht = self.Utility.cp
+            rho_ht = self.Utility.rho
 
-            vol_ht = self.vol_tank*0.14  # [m**3]
+            vol_ht = self.vol_tank*0.14  # m**3
 
             dtht_dt = flow_ht / vol_ht * (tht_in - temp_ht) - \
-                self.u_ht*area_ht*(temp_ht - temp) / rho_ht/vol_ht/cp_ht  # [K/s]
+                self.u_ht*area_ht*(temp_ht - temp) / rho_ht/vol_ht/cp_ht
 
             return dtemp_dt, dtht_dt
 
@@ -2118,7 +2118,7 @@ class SemibatchCryst(MSMPR):
         rho_in_liq, _ = rho_in
 
         input_flow = u_inputs['Inlet']['vol_flow']
-        input_flow = np.max([eps, input_flow])  # [m**3/s]
+        input_flow = np.max([eps, input_flow])
 
         # TODO: generalize dictionary iteration ('Inlet', 'Liquid_1', ...)?
         input_distrib = u_inputs['Inlet']['distrib'] * self.scale
@@ -2172,59 +2172,59 @@ class SemibatchCryst(MSMPR):
         rho_susp, rho_in = rhos
 
         # Input properties
-        input_flow = u_inputs['Inlet']['vol_flow']  # [m**3/s]
-        input_flow = np.max([eps, input_flow])  # [m**3/s]
+        input_flow = u_inputs['Inlet']['vol_flow']
+        input_flow = np.max([eps, input_flow])
 
-        vol_solid = mu_n[3] * self.Solid_1.kv  # [m**3]
-        vol_total = vol + vol_solid  # [m**3]
+        vol_solid = mu_n[3] * self.Solid_1.kv  # mu_3 is total, not by volume
+        vol_total = vol + vol_solid
 
-        phi = vol / vol_total  # [-]
+        phi = vol / vol_total
         phis = [phi, 1 - phi]
-        dens_slurry = np.dot(rho_susp, phis)  # [kg/m**3]
+        dens_slurry = np.dot(rho_susp, phis)
 
         # Suspension properties
         capacitance = self.Slurry.getCp(temp, phis, rho_susp,
-                                        times_vliq=True)  # [J/m**3/K]
-        h_sp = self.Slurry.getEnthalpy(temp, phis, rho_susp)  # [J/m**3]
+                                        times_vliq=True)
+        h_sp = self.Slurry.getEnthalpy(temp, phis, rho_susp)
 
         # Renaming
-        dh_cryst = -1.46e4  # [J/kg]
+        dh_cryst = -1.46e4  # J/kg
         # dh_cryst = -self.Liquid_1.delta_fus[self.target_ind] / \
         #     self.Liquid_1.mw[self.target_ind] * 1000  # J/kg
 
         # Terms
-        dens_in_liq = rho_in[0]  # [kg/m**3]
-        dmass_dt = input_flow * dens_in_liq  # [kg/s]
+        dens_in_liq = rho_in[0]
+        dmass_dt = input_flow * dens_in_liq
 
-        accum_term = dmass_dt * h_sp/dens_slurry  # [J/s]
-        flow_term = input_flow * h_in  # [J/s]
+        accum_term = dmass_dt * h_sp/dens_slurry
+        flow_term = input_flow * h_in
 
-        source_term = dh_cryst * cryst_rate  # [J/s]
+        source_term = dh_cryst * cryst_rate
 
-        height_liq = vol / (np.pi/4 * self.diam_tank**2)  # [m]
-        area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # [m**2]
+        height_liq = vol / (np.pi/4 * self.diam_tank**2)
+        area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # m**2
 
         if self.adiabatic:
-            ht_term = 0  # [J/s]
+            ht_term = 0
         else:
-            ht_term = self.u_ht*area_ht*(temp - temp_ht)  # [J/s]
+            ht_term = self.u_ht*area_ht*(temp - temp_ht)
 
         # Balance inside the tank
         dtemp_dt = (flow_term - source_term - ht_term - accum_term) / \
-            capacitance / vol  # [K/s]
+            capacitance / vol
 
         # print(dtemp_dt)
 
         if temp_ht is not None:
             ht_media = self.Utility.get_inputs(time)
-            tht_in = ht_media['temp_in']  # [K]
-            flow_ht = ht_media['vol_flow']  # [m**3/s]
-            cp_ht = self.Utility.cp  # [J/kg/K]
-            rho_ht = self.Utility.rho  # [kg/m**3]
-            vol_ht = self.vol_tank*0.14  # [m**3]
+            tht_in = ht_media['temp_in']
+            flow_ht = ht_media['vol_flow']
+            cp_ht = self.Utility.cp
+            rho_ht = self.Utility.rho
+            vol_ht = self.vol_tank*0.14  # m**3
 
             dtht_dt = flow_ht / vol_ht * (tht_in - temp_ht) - \
-                self.u_ht*area_ht*(temp_ht - temp) / rho_ht/vol_ht/cp_ht  # [K/s]
+                self.u_ht*area_ht*(temp_ht - temp) / rho_ht/vol_ht/cp_ht
 
             return dtemp_dt, dtht_dt
 

--- a/PharmaPy/Crystallizers.py
+++ b/PharmaPy/Crystallizers.py
@@ -2217,11 +2217,11 @@ class SemibatchCryst(MSMPR):
 
         if temp_ht is not None:
             ht_media = self.Utility.get_inputs(time)
-            tht_in = ht_media['temp_in']
-            flow_ht = ht_media['vol_flow']
-            cp_ht = self.Utility.cp
-            rho_ht = self.Utility.rho
-            vol_ht = self.vol_tank*0.14  # m**3
+            tht_in = ht_media['temp_in']  # [K]
+            flow_ht = ht_media['vol_flow']  # [m**3/s]
+            cp_ht = self.Utility.cp  # [J/kg/K]
+            rho_ht = self.Utility.rho  # [kg/m**3]
+            vol_ht = self.vol_tank*0.14  # [m**3]
 
             dtht_dt = flow_ht / vol_ht * (tht_in - temp_ht) - \
                 self.u_ht*area_ht*(temp_ht - temp) / rho_ht/vol_ht/cp_ht

--- a/PharmaPy/MixedPhases.py
+++ b/PharmaPy/MixedPhases.py
@@ -328,11 +328,11 @@ class Slurry:
         # Mixture
         if volfracs is None:
             volfracs = self.getFractions()
-        volfracs = np.array(volfracs, copy=True)  # [-]
+        volfracs = np.array(volfracs, copy=True)
 
         if density is None:
             density = self.getDensity()
-        density = np.asarray(density)  # [kg/m**3]
+        density = np.asarray(density)
 
         self.epsilon = volfracs.copy()
         self.densities = density
@@ -340,7 +340,7 @@ class Slurry:
         if times_vliq:
             volfracs[1] *= 1/volfracs[0]
 
-        cpSlurry = sum(volfracs * density * cpPhases)  # [J/m**3/K]
+        cpSlurry = sum(volfracs * density * cpPhases)  # J/m**3/K
 
         return cpSlurry
 

--- a/PharmaPy/MixedPhases.py
+++ b/PharmaPy/MixedPhases.py
@@ -328,17 +328,19 @@ class Slurry:
         # Mixture
         if volfracs is None:
             volfracs = self.getFractions()
+        volfracs = np.array(volfracs, copy=True)  # [-]
 
         if density is None:
             density = self.getDensity()
+        density = np.asarray(density)  # [kg/m**3]
 
-        self.epsilon = volfracs
+        self.epsilon = volfracs.copy()
         self.densities = density
 
         if times_vliq:
             volfracs[1] *= 1/volfracs[0]
 
-        cpSlurry = sum(volfracs * density * cpPhases)  # J/m**3/K
+        cpSlurry = sum(volfracs * density * cpPhases)  # [J/m**3/K]
 
         return cpSlurry
 

--- a/tests/test_crystallizer_energy_balances.py
+++ b/tests/test_crystallizer_energy_balances.py
@@ -4,17 +4,31 @@ import types
 import numpy as np
 import pytest
 
+_MISSING = object()
+_ASSIMULO_STUBS = {}
+
 try:
     from assimulo.problem import Explicit_Problem  # noqa: F401
     from assimulo.solvers import CVode  # noqa: F401
 except ImportError:
     for module_name in ("assimulo", "assimulo.problem", "assimulo.solvers"):
-        sys.modules.setdefault(module_name, types.ModuleType(module_name))
+        _ASSIMULO_STUBS[module_name] = sys.modules.get(module_name, _MISSING)
+        sys.modules[module_name] = types.ModuleType(module_name)
 
+    sys.modules["assimulo"].problem = sys.modules["assimulo.problem"]
+    sys.modules["assimulo"].solvers = sys.modules["assimulo.solvers"]
     sys.modules["assimulo.problem"].Explicit_Problem = object
     sys.modules["assimulo.solvers"].CVode = object
 
-from PharmaPy.Crystallizers import MSMPR, SemibatchCryst
+try:
+    from PharmaPy.Crystallizers import MSMPR, SemibatchCryst
+finally:
+    for module_name, previous in reversed(_ASSIMULO_STUBS.items()):
+        if previous is _MISSING:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous
+
 from PharmaPy.MixedPhases import Slurry
 
 

--- a/tests/test_crystallizer_energy_balances.py
+++ b/tests/test_crystallizer_energy_balances.py
@@ -1,3 +1,9 @@
+"""Test crystallizer energy balance regressions.
+
+This module covers unit-basis and utility-jacket paths for crystallizer energy
+balances.
+"""
+
 import sys
 import types
 

--- a/tests/test_crystallizer_energy_balances.py
+++ b/tests/test_crystallizer_energy_balances.py
@@ -1,0 +1,184 @@
+import sys
+import types
+
+import numpy as np
+import pytest
+
+try:
+    from assimulo.problem import Explicit_Problem  # noqa: F401
+    from assimulo.solvers import CVode  # noqa: F401
+except ImportError:
+    for module_name in ("assimulo", "assimulo.problem", "assimulo.solvers"):
+        sys.modules.setdefault(module_name, types.ModuleType(module_name))
+
+    sys.modules["assimulo.problem"].Explicit_Problem = object
+    sys.modules["assimulo.solvers"].CVode = object
+
+from PharmaPy.Crystallizers import MSMPR, SemibatchCryst
+from PharmaPy.MixedPhases import Slurry
+
+
+class StubPhase:
+    kv = 0.5  # [-]
+
+    def updatePhase(self, **kwargs):
+        pass
+
+    def getCp(self, temp=None, basis="mass"):
+        cp_mass = 4000.0  # [J/kg/K]
+        return cp_mass
+
+    def getDensity(self, temp=None):
+        density = 1000.0  # [kg/m**3]
+        return density
+
+    def getEnthalpy(self, temp=None, basis="mass"):
+        h_mass = 1.0e5  # [J/kg]
+        return h_mass
+
+
+class StubSlurry:
+    vol = 1.0e-3  # [m**3]
+    temp_ht = None
+
+    def getDensity(self, temp=None):
+        density = np.array([1000.0, 2000.0])  # [kg/m**3]
+        return density
+
+    def getEnthalpy(self, temp, volfracs, density):
+        h_vol = 2.0e8  # [J/m**3]
+        return h_vol
+
+    def getCp(self, temp, volfracs, density, times_vliq=False):
+        cp_vol = 3.0e6  # [J/m**3/K]
+        return cp_vol
+
+
+class StubUtility:
+    cp = 3500.0  # [J/kg/K]
+    rho = 800.0  # [kg/m**3]
+
+    def get_inputs(self, time):
+        temp_in = 285.0  # [K]
+        vol_flow = 2.0e-5  # [m**3/s]
+        return {"temp_in": temp_in, "vol_flow": vol_flow}
+
+
+class LiquidInlet:
+    def getDensity(self, temp=None):
+        rho_liq = 950.0  # [kg/m**3]
+        return rho_liq
+
+    def getEnthalpy(self, temp=None):
+        h_mass = 123.0  # [J/kg]
+        return h_mass
+
+
+def _common_energy_attrs(cryst):
+    cryst.Solid_1 = StubPhase()
+    cryst.Slurry = StubSlurry()
+    cryst.controls = {}
+
+    cryst.diam_tank = 0.1  # [m]
+    cryst.area_base = 0.01  # [m**2]
+    cryst.u_ht = 500.0  # [J/s/m**2/K]
+    cryst.vol_tank = 1.0e-3  # [m**3]
+
+
+COMMON_ENERGY_KW = {
+    "time": 0.0,  # [s]
+    "params": {},
+    "cryst_rate": 0.0,  # [kg/s]
+    "u_inputs": {"Inlet": {"vol_flow": 1.0e-6}},  # [m**3/s]
+    "rhos": [np.array([1000.0, 2000.0]), np.array([1000.0, None])],  # [kg/m**3]
+    "distrib": None,
+    "mass_conc": None,
+    "temp": 300.0,  # [K]
+    "vol": 1.0e-3,  # [m**3]
+    "h_in": 1.0e5,  # [J/m**3]
+}
+
+
+def test_msmpr_adiabatic_energy_balance_has_no_jacket_equation():
+    cryst = MSMPR.__new__(MSMPR)
+    _common_energy_attrs(cryst)
+    cryst.adiabatic = True
+    cryst.states_uo = ["distrib", "mass_conc", "vol", "temp"]
+
+    dtemp_dt = cryst.energy_balances(  # [K/s]
+        mu_n=np.zeros(4), temp_ht=None, **COMMON_ENERGY_KW
+    )
+
+    assert np.ndim(dtemp_dt) == 0
+
+
+def test_semibatch_jacket_uses_utility_inputs():
+    cryst = SemibatchCryst.__new__(SemibatchCryst)
+    _common_energy_attrs(cryst)
+    cryst.adiabatic = False
+    cryst._Utility = StubUtility()
+
+    temp_ht = 290.0  # [K]
+    dtemp_dt, dtht_dt = cryst.energy_balances(  # [K/s]
+        mu_n=np.zeros(4), temp_ht=temp_ht, **COMMON_ENERGY_KW
+    )
+
+    assert np.isfinite(dtemp_dt)
+    assert np.isfinite(dtht_dt)
+
+
+def test_liquid_feed_enthalpy_passed_to_energy_balance_is_volumetric():
+    cryst = MSMPR.__new__(MSMPR)
+    cryst.dim_states = [4, 1, 1]
+    cryst.name_states = ["mu_n", "mass_conc", "temp"]
+    cryst.method = "moments"
+    cryst.states_di = {"mu_n": {"dim": 4}}
+    cryst.scale = 1.0  # [-]
+    cryst.controls = {}
+    cryst.Slurry = StubSlurry()
+    cryst.Liquid_1 = StubPhase()
+    cryst.Solid_1 = StubPhase()
+    cryst._Inlet = LiquidInlet()
+
+    inlet_temp = 305.0  # [K]
+    inlet_vol_flow = 2.0e-6  # [m**3/s]
+    cryst.get_inputs = lambda time: {
+        "Inlet": {"temp": inlet_temp, "vol_flow": inlet_vol_flow}
+    }
+
+    captured = {}
+
+    def material_balances(*args, **kwargs):
+        material_rates = np.zeros(5)  # [kg/m**3/s]
+        cryst_rate = 0.0  # [kg/s]
+        return material_rates, cryst_rate
+
+    def energy_balances(*args, h_in, **kwargs):
+        captured["h_in"] = h_in
+        return h_in
+
+    cryst.material_balances = material_balances
+    cryst.energy_balances = energy_balances
+
+    moments = np.zeros(4)  # [m**n/m**3]
+    mass_conc = np.array([10.0])  # [kg/m**3]
+    temp = np.array([300.0])  # [K]
+    states = np.concatenate([moments, mass_conc, temp])
+
+    result = cryst.unit_model(0.0, states, params={}, enrgy_bce=True)  # [J/m**3]
+
+    expected_h_in = 123.0 * 950.0  # [J/kg]*[kg/m**3] -> [J/m**3]
+    assert result == pytest.approx(expected_h_in)
+    assert captured["h_in"] == pytest.approx(expected_h_in)
+
+
+def test_slurry_getcp_times_vliq_does_not_mutate_volfracs():
+    slurry = Slurry.__new__(Slurry)
+    slurry.Liquid_1 = StubPhase()
+    slurry.Solid_1 = StubPhase()
+
+    volfracs = [0.9, 0.1]  # [-]
+    density = np.array([1000.0, 2000.0])  # [kg/m**3]
+    slurry.getCp(300.0, volfracs, density, times_vliq=True)
+
+    assert volfracs == pytest.approx([0.9, 0.1])


### PR DESCRIPTION
Closes #68

## Summary

- Converts plain-liquid crystallizer inlet enthalpy from mass-specific to volumetric basis before it reaches MSMPR/Semibatch energy balances.
- Adds the missing adiabatic MSMPR energy-balance path so it returns only the tank temperature derivative when no jacket state exists.
- Reads Semibatch jacket inlet temperature, flow, Cp, and density from `Utility`, matching the established MSMPR/reactor pattern.
- Copies slurry volume fractions inside `Slurry.getCp` before `times_vliq` scaling so callers do not see mutated `volfracs`.
- Adds focused regression coverage for the four issue #68 defects.

## Tests

- `pytest tests/test_crystallizer_energy_balances.py`
- `pytest` (default environment: 32 passed, 6 skipped because Assimulo is unavailable there)
- `/home/andresfel9403/anaconda3/bin/conda run -n PharmaPy python -m pytest` (38 passed with Assimulo 3.4.3)
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check`

## Branch Hygiene

- Base branch: `master`
- Source branch point: `origin/master` at `4098d776613ecfab3d65e244a027cf58c3fe3c4a`
- Head branch: `fix/issue-68-crystallizer-energy`
- Stacked status: not stacked; no prerequisite PRs.
- Upstream sync: `upstream/master` at `400e1e13ad4ecd3ba202d5fae8c70ec73bdf9c3e` is already contained in `origin/master`.
