### PR TITLE
Fix reactor mode crash paths

### DIFF
--- a/PharmaPy/Reactors.py
+++ b/PharmaPy/Reactors.py
@@ -949,7 +949,8 @@ class CSTR(_BaseReactor):
         whether or not the paramest_wrapper method should return
         the sensitivity system along with the concentratio profiles.
         Use False if you want the parameter estimation platform to
-        estimate the sensitivity system using finite differences
+        estimate the sensitivity system using finite differences.
+        Direct sensitivity evaluation is not implemented for CSTR.
     """
 
     def __init__(self, mask_params=None,
@@ -1099,10 +1100,16 @@ class CSTR(_BaseReactor):
 
         if eval_sens:
             raise NotImplementedError(
-                "CSTR sensitivity evaluation is not supported")
+                "CSTR sensitivity evaluation is not supported; construct "
+                "with return_sens=False to use finite-difference "
+                "sensitivities")
 
         self.params_control = params_control
         self.set_names()
+
+        if self.ht_mode == 'coil' and not self.isothermal:
+            raise NotImplementedError(
+                "CSTR heat transfer with ht_mode='coil' is not supported")
 
         self.num_concentr = len(self.Liquid_1.mole_conc)
         self.args_inputs = (self, self.num_concentr, 0)
@@ -1253,7 +1260,8 @@ class SemibatchReactor(CSTR):
         whether or not the paramest_wrapper method should return
         the sensitivity system along with the concentratio profiles.
         Use False if you want the parameter estimation platform to
-        estimate the sensitivity system using finite differences
+        estimate the sensitivity system using finite differences.
+        Direct sensitivity evaluation is not implemented for SemibatchReactor.
     """
     
     def __init__(self, vol_tank,
@@ -1304,10 +1312,17 @@ class SemibatchReactor(CSTR):
 
         if eval_sens:
             raise NotImplementedError(
-                "SemibatchReactor sensitivity evaluation is not supported")
+                "SemibatchReactor sensitivity evaluation is not supported; "
+                "construct with return_sens=False to use finite-difference "
+                "sensitivities")
 
         self.params_control = params_control
         self.set_names()
+
+        if self.ht_mode == 'coil' and not self.isothermal:
+            raise NotImplementedError(
+                "SemibatchReactor heat transfer with ht_mode='coil' is "
+                "not supported")
 
         if runtime is not None:
             final_time = runtime + self.elapsed_time
@@ -1560,17 +1575,15 @@ class PlugFlowReactor(_BaseReactor):
                                             delta_hrxn=deltah_rxn)
 
         # ---------- Balance terms (W)
-        # source_term = -inner1d(deltah_rxn, rates) * 1000  # W/m**3
-        # TODO: Check if this is correct
-        # source_term = -np.dot(deltah_rxn, rates) * 1000  # W / m**3
-        source_term = -np.sum(deltah_rxn * rates) * 1000  # W / m**3
+        source_term = -np.dot(deltah_rxn, rates) * 1000  # W / m**3
 
         if self.adiabatic:
             heat_transfer = 0
         else:  # W/m**3
+            # The steady-PFR area formula is a pre-existing issue tracked in #33.
             a_prime = self.diam / 4  # m**2 / m**3
-            temp_ht = self.Utility.evaluate_inputs(0)['temp_in']
-            heat_transfer = self.u_ht * a_prime * (temp - temp_ht)
+            heat_transfer = self.u_ht * a_prime * (
+                temp - self.temp_ht_steady)
 
         flow_term = self.Inlet.vol_flow * cp_vol
 
@@ -1617,6 +1630,11 @@ class PlugFlowReactor(_BaseReactor):
 
         if 'temp' in self.states_uo:
             states_init = np.append(states_init, self.Inlet.temp)
+
+        if 'temp' in self.states_uo and not self.adiabatic:
+            # The steady solve integrates over volume, not time, so use the
+            # inlet utility condition at the start of the volume profile.
+            self.temp_ht_steady = self.Utility.evaluate_inputs(0)['temp_in']
 
         problem = Explicit_Problem(self.unit_steady, states_init, t0=0)
         solver = CVode(problem)

--- a/PharmaPy/Reactors.py
+++ b/PharmaPy/Reactors.py
@@ -292,9 +292,11 @@ class _BaseReactor:
         return events
 
     def heat_transfer(self, temp, temp_ht, vol):
+        """Return reactor heat transfer duty for supported heat-transfer modes."""
         # Heat transfer area
         if self.ht_mode == 'coil':  # Half pipe heat transfer
-            pass
+            raise NotImplementedError(
+                "heat_transfer with ht_mode='coil' is not supported")
         else:
             area_ht = 4 / self.diam * vol + self.area_base  # m**2
             heat_transf = self.u_ht * area_ht * (temp - temp_ht)
@@ -1095,6 +1097,10 @@ class CSTR(_BaseReactor):
 
         check_modeling_objects(self)
 
+        if eval_sens:
+            raise NotImplementedError(
+                "CSTR sensitivity evaluation is not supported")
+
         self.params_control = params_control
         self.set_names()
 
@@ -1131,14 +1137,11 @@ class CSTR(_BaseReactor):
 
         # Create problem
         merged_params = self.Kinetics.concat_params()
-        if eval_sens:
-            pass
-        else:
-            def fobj(time, states): return self.unit_model(
-                time, states, merged_params)
+        def fobj(time, states): return self.unit_model(
+            time, states, merged_params)
 
-            problem = Explicit_Problem(fobj, states_init,
-                                       t0=self.elapsed_time)
+        problem = Explicit_Problem(fobj, states_init,
+                                   t0=self.elapsed_time)
 
         # Set solver
         solver = CVode(problem)
@@ -1299,6 +1302,10 @@ class SemibatchReactor(CSTR):
 
         check_modeling_objects(self)
 
+        if eval_sens:
+            raise NotImplementedError(
+                "SemibatchReactor sensitivity evaluation is not supported")
+
         self.params_control = params_control
         self.set_names()
 
@@ -1323,14 +1330,11 @@ class SemibatchReactor(CSTR):
                 states_init = np.append(states_init, tht_init)
 
         merged_params = self.Kinetics.concat_params()
-        if eval_sens:
-            pass
-        else:
-            def fobj(time, states): return self.unit_model(
-                time, states, merged_params)
+        def fobj(time, states): return self.unit_model(
+            time, states, merged_params)
 
-            problem = Explicit_Problem(fobj, states_init,
-                                       t0=self.elapsed_time)
+        problem = Explicit_Problem(fobj, states_init,
+                                   t0=self.elapsed_time)
 
         # Set solver
         solver = CVode(problem)
@@ -1559,13 +1563,14 @@ class PlugFlowReactor(_BaseReactor):
         # source_term = -inner1d(deltah_rxn, rates) * 1000  # W/m**3
         # TODO: Check if this is correct
         # source_term = -np.dot(deltah_rxn, rates) * 1000  # W / m**3
-        source_term = -(deltah_rxn * rates).sum(axis=1) * 1000  # W / m**3
+        source_term = -np.sum(deltah_rxn * rates) * 1000  # W / m**3
 
         if self.adiabatic:
             heat_transfer = 0
         else:  # W/m**3
             a_prime = self.diam / 4  # m**2 / m**3
-            heat_transfer = self.u_ht * a_prime * (temp - self.Utility.temp)
+            temp_ht = self.Utility.evaluate_inputs(0)['temp_in']
+            heat_transfer = self.u_ht * a_prime * (temp - temp_ht)
 
         flow_term = self.Inlet.vol_flow * cp_vol
 
@@ -1601,7 +1606,7 @@ class PlugFlowReactor(_BaseReactor):
             self.isothermal = False
             self.states_uo.append('temp')
 
-        c_inlet = self.Inlet.concentr
+        c_inlet = self.Inlet.mole_conc
 
         self.c_inert = c_inlet[~self.mask_species]
         c_partic = c_inlet[self.mask_species]

--- a/tests/test_reactor_modes.py
+++ b/tests/test_reactor_modes.py
@@ -41,7 +41,12 @@ def _load_pfr_config(data_path):
     config["inlet"]["vol_flow"] = config["phase"]["vol"] / tau
 
     datapath = str(data_path["integration"] / "pfr_test_pure_comp.json")
-    config["kinetics"]["k_params"] *= 1 / 60
+    config["kinetics"].update({
+        "stoich_matrix": [[-1, -1, 1], [0, -1, 1]],
+        "k_params": [40 / 60, 10 / 60],
+        "ea_params": [2e3, 1e3],
+        "delta_hrxn": [-5e3, -2.5e3],
+    })
     config["kinetics"]["path"] = datapath
 
     return config, datapath
@@ -76,6 +81,9 @@ def test_pfr_solve_steady_reads_inlet_mole_conc(data_path):
     assert vol_position.size > 1
     assert states.shape[0] == vol_position.size
     assert reactor.concProfSteady.shape[0] == vol_position.size
+    assert reactor.Kinetics.num_rxns == 2
+    assert reactor.tempProfSteady[-1] > reactor.Inlet.temp
+    assert reactor.tempProfSteady[-1] < reactor.temp_ht_steady
 
 
 @pytest.mark.parametrize("reactor_cls", SENSITIVITY_REACTORS)
@@ -96,3 +104,17 @@ def test_coil_ht_mode_refuses_unsupported_heat_transfer():
 
     with pytest.raises(NotImplementedError, match="coil.*not supported"):
         reactor.heat_transfer(np.array([300.0]), np.array([290.0]), 0.002)
+
+
+@pytest.mark.parametrize("reactor_cls", SENSITIVITY_REACTORS)
+def test_coil_ht_mode_refuses_through_solve_unit(data_path, reactor_cls):
+    if reactor_cls is CSTR:
+        reactor = reactor_cls(isothermal=False, ht_mode="coil")
+    else:
+        reactor = reactor_cls(
+            vol_tank=0.002, isothermal=False, ht_mode="coil")
+
+    reactor = _reactor_objects(data_path, reactor)
+
+    with pytest.raises(NotImplementedError, match="coil.*not supported"):
+        reactor.solve_unit(runtime=1, verbose=False)

--- a/tests/test_reactor_modes.py
+++ b/tests/test_reactor_modes.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+import copy
+import importlib.util
+import json
+
+import numpy as np
+import pytest
+
+
+HAS_ASSIMULO = importlib.util.find_spec("assimulo") is not None
+
+pytestmark = [
+    pytest.mark.assimulo,
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not HAS_ASSIMULO,
+        reason="assimulo is not installed; solver-backed integration tests skipped",
+    ),
+]
+
+if HAS_ASSIMULO:
+    from PharmaPy.Kinetics import RxnKinetics
+    from PharmaPy.Phases import LiquidPhase
+    from PharmaPy.Reactors import CSTR, BatchReactor, PlugFlowReactor
+    from PharmaPy.Reactors import SemibatchReactor
+    from PharmaPy.Streams import LiquidStream
+    from PharmaPy.Utilities import CoolingWater
+
+    SENSITIVITY_REACTORS = [CSTR, SemibatchReactor]
+else:
+    SENSITIVITY_REACTORS = []
+
+
+def _load_pfr_config(data_path):
+    with open(data_path["integration"] / "pfr_test_constructor_kwargs.json") as f:
+        config = json.load(f)
+
+    config = copy.deepcopy(config)
+    tau = config["inlet"].pop("tau")
+    config["inlet"]["vol_flow"] = config["phase"]["vol"] / tau
+
+    datapath = str(data_path["integration"] / "pfr_test_pure_comp.json")
+    config["kinetics"]["k_params"] *= 1 / 60
+    config["kinetics"]["path"] = datapath
+
+    return config, datapath
+
+
+def _reactor_objects(data_path, reactor):
+    config, datapath = _load_pfr_config(data_path)
+
+    inlet = LiquidStream(datapath, **config["inlet"])
+    phase = LiquidPhase(datapath, **config["phase"])
+    kinetics = RxnKinetics(**config["kinetics"])
+    utility = CoolingWater(**config["utility"])
+
+    reactor.Inlet = inlet
+    reactor.Phases = phase
+    reactor.Kinetics = kinetics
+    reactor.Utility = utility
+
+    return reactor
+
+
+def test_pfr_solve_steady_reads_inlet_mole_conc(data_path):
+    config, _ = _load_pfr_config(data_path)
+    reactor = _reactor_objects(
+        data_path, PlugFlowReactor(**config["reactor"])
+    )
+
+    vol_position, states = reactor.solve_steady(reactor.Liquid_1.vol)
+
+    vol_position = np.asarray(vol_position)
+
+    assert vol_position.size > 1
+    assert states.shape[0] == vol_position.size
+    assert reactor.concProfSteady.shape[0] == vol_position.size
+
+
+@pytest.mark.parametrize("reactor_cls", SENSITIVITY_REACTORS)
+def test_sensitivity_mode_refuses_unsupported_reactors(data_path, reactor_cls):
+    if reactor_cls is CSTR:
+        reactor = reactor_cls()
+    else:
+        reactor = reactor_cls(vol_tank=0.002)
+
+    reactor = _reactor_objects(data_path, reactor)
+
+    with pytest.raises(NotImplementedError, match="sensitivity.*not supported"):
+        reactor.solve_unit(runtime=1, eval_sens=True, verbose=False)
+
+
+def test_coil_ht_mode_refuses_unsupported_heat_transfer():
+    reactor = BatchReactor(isothermal=False, ht_mode="coil")
+
+    with pytest.raises(NotImplementedError, match="coil.*not supported"):
+        reactor.heat_transfer(np.array([300.0]), np.array([290.0]), 0.002)


### PR DESCRIPTION
## Summary

Closes #70.

- Use `LiquidStream.mole_conc` in `PlugFlowReactor.solve_steady` instead of the non-existent `concentr` attribute.
- Fix steady PFR energy-balance crashes reached after the inlet-concentration fix by treating the steady rate/source term as scalar and reading the utility `temp_in` input.
- Replace CSTR/Semibatch `eval_sens=True` fall-throughs and coil heat-transfer fall-through with explicit `NotImplementedError` messages naming the unsupported modes.
- Add Assimulo-marked regressions for the documented PFR, sensitivity, and coil-mode crash paths.

## Tests

- `conda run -n pharmapy python -m pytest --collect-only -q`
- `conda run -n pharmapy python -m pytest tests/test_reactor_modes.py -q`
- `conda run -n pharmapy python -m pytest tests/ -m "not assimulo" -q`
- `conda run -n pharmapy python -m pytest tests/ -m assimulo -q`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,cr-at-eol diff --cached --check`

## Branch Hygiene

- Base branch: `master`
- Source branch point: `origin/master` at `1a3ab31`
- Upstream status: `origin/master` contains `upstream/master` at `400e1e1`
- Stacked status: none; no prerequisite PRs
