### PR TITLE
Fix drying gas mass-rate balance

### DIFF
--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -217,6 +217,7 @@ class Drying:
         return dry_rates
 
     def _drying_rate_mass_basis(self, dry_rate):
+        """Convert molar drying rates [mol/m**3/s] to mass rates [kg/m**3/s]."""
         mw = np.asarray(self.Liquid_1.mw) / 1000  # [kg/mol]
 
         return dry_rate * mw
@@ -267,10 +268,11 @@ class Drying:
 
         limiter_factor = self.eta_fun(sat_eta, w_eta)
 
-        # Dry rate
+        # Drying rate from get_drying_rate is molar [mol/m**3/s].
         self.dry_rate = self.get_drying_rate(x_liq, temp_sol, y_gas,
                                              self.pres_gas)
 
+        # Balances below consume mass-basis drying rates [kg/m**3/s].
         self.dry_rate = self._drying_rate_mass_basis(self.dry_rate)
         self.dry_rate *= limiter_factor[..., np.newaxis]
 

--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -216,6 +216,11 @@ class Drying:
 
         return dry_rates
 
+    def _drying_rate_mass_basis(self, dry_rate):
+        mw = np.asarray(self.Liquid_1.mw) / 1000  # [kg/mol]
+
+        return dry_rate * mw
+
     def unit_model(self, time, states, sw=None):
         '''
         state vector in the order: S|w_gas|w_liq|Tg|Ts
@@ -266,6 +271,7 @@ class Drying:
         self.dry_rate = self.get_drying_rate(x_liq, temp_sol, y_gas,
                                              self.pres_gas)
 
+        self.dry_rate = self._drying_rate_mass_basis(self.dry_rate)
         self.dry_rate *= limiter_factor[..., np.newaxis]
 
         # ---------- Model equations
@@ -299,16 +305,13 @@ class Drying:
         # ----- Liquid phase
         dens_liq = self.rho_liq
 
-        # Convert molar drying rates to mass rates for the liquid balance (#20).
-        # Gas and energy balances still use molar rates pending #21 and #48.
-        mw_volatiles = self.Liquid_1.mw[self.idx_volatiles] / 1000  # [kg/mol]
-        dry_rate_mass = dry_rate[:, self.idx_volatiles] * mw_volatiles  # [kg/m**3/s]
-        sum_dry = dry_rate_mass.sum(axis=1)  # [kg/m**3/s]
+        dry_rate_volatiles = dry_rate[:, self.idx_volatiles]
+        sum_dry = dry_rate_volatiles.sum(axis=1)  # [kg/m**3/s]
 
         dsat_dt = -sum_dry / dens_liq / self.porosity
 
         dxliq_dt = -1 / satur* \
-            (dry_rate_mass.T / dens_liq / self.porosity +
+            (dry_rate_volatiles.T / dens_liq / self.porosity +
               x_liq.T * dsat_dt)
 
         # ----- Gas phase

--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -201,6 +201,24 @@ class Drying:
         return y_equil
 
     def get_drying_rate(self, x_liq, temp_cond, y_gas, p_gas):
+        """Calculate component drying rates on a molar basis.
+
+        Parameters
+        ----------
+        x_liq : ndarray
+            Liquid mass fractions for volatile components [-].
+        temp_cond : ndarray
+            Condensed-phase temperature [K].
+        y_gas : ndarray
+            Gas-phase mass fractions for all vapor species [-].
+        p_gas : float
+            Gas pressure [Pa].
+
+        Returns
+        -------
+        ndarray
+            Component drying rates on a molar basis [mol/m**3/s].
+        """
 
         y_gas_mole_frac = self.Vapor_1.frac_to_frac(mass_frac=y_gas)
         y_equil = self.get_y_equilib(temp_cond, x_liq, p_gas)
@@ -234,8 +252,25 @@ class Drying:
         return dry_rate * mw
 
     def unit_model(self, time, states, sw=None):
-        """
-        state vector in the order: S|w_gas|w_liq|Tg|Ts
+        """Evaluate the drying model residual equations.
+
+        Parameters
+        ----------
+        time : float
+            Current integration time [s].
+        states : ndarray
+            Flattened state vector ordered by node as
+            ``S|w_gas|w_liq|Tg|Ts``; saturation and mass fractions are
+            dimensionless [-], and temperatures are [K].
+        sw : sequence of bool, optional
+            Assimulo event switches [-].
+
+        Returns
+        -------
+        ndarray
+            Flattened state derivatives ordered like ``states``. Saturation
+            and mass-fraction derivatives are [1/s]; temperature derivatives
+            are [K/s].
         """
 
         num_comp = self.Liquid_1.num_species
@@ -309,41 +344,75 @@ class Drying:
 
     def material_balance(self, time, satur, temp_gas, temp_sol, y_gas, x_liq,
                          u_gas, dens_gas, dry_rate, inputs, return_terms=False):
+        """Evaluate the saturation and composition material balances.
+
+        Parameters
+        ----------
+        time : float
+            Current integration time [s].
+        satur : ndarray
+            Cake saturation by spatial node [-].
+        temp_gas : ndarray
+            Gas-phase temperature by spatial node [K].
+        temp_sol : ndarray
+            Condensed-phase temperature by spatial node [K].
+        y_gas : ndarray
+            Gas-phase mass fractions by node and species [-].
+        x_liq : ndarray
+            Liquid mass fractions by node and volatile species [-].
+        u_gas : ndarray
+            Gas velocity by spatial node [m/s].
+        dens_gas : ndarray
+            Gas density by spatial node [kg/m**3].
+        dry_rate : ndarray
+            Component drying rates on a mass basis [kg/m**3/s].
+        inputs : dict
+            Inlet condition dictionary; ``mass_frac`` entries are gas mass
+            fractions [-].
+        return_terms : bool, optional
+            Return stored diagnostic terms instead of balance derivatives [-].
+
+        Returns
+        -------
+        list of ndarray
+            ``dsat_dt`` [1/s], ``dygas_dt`` [1/s], and ``dxliq_dt`` [1/s].
+        """
         
         satur[satur < eps] = eps
         satur[satur >= 1] = 1 - eps
         # ----- Reading inputs
-        y_gas_inputs = inputs['mass_frac']
+        y_gas_inputs = inputs['mass_frac']  # [-]
 
         # ----- Liquid phase
-        dens_liq = self.rho_liq
+        dens_liq = self.rho_liq  # [kg/m**3]
 
         dry_rate_volatiles = dry_rate[:, self.idx_volatiles]  # [kg/m**3/s]
         sum_dry = dry_rate_volatiles.sum(axis=1)  # [kg/m**3/s]
 
-        dsat_dt = -sum_dry / dens_liq / self.porosity
+        dsat_dt = -sum_dry / dens_liq / self.porosity  # [1/s]
 
         dxliq_dt = -1 / satur* \
             (dry_rate_volatiles.T / dens_liq / self.porosity +
-              x_liq.T * dsat_dt)
+              x_liq.T * dsat_dt)  # [1/s]
 
         # ----- Gas phase
         # Convective term
-        epsilon_gas = self.porosity * (1 - satur)
-        epsilon_gas[epsilon_gas <= eps] = eps
+        epsilon_gas = self.porosity * (1 - satur)  # [-]
+        epsilon_gas[epsilon_gas <= eps] = eps  # [-]
 
         # fluxes_yg = high_resolution_fvm(y_gas, boundary_cond=y_gas_inputs)
-        fluxes_yg = upwind_fvm(y_gas, boundary_cond=y_gas_inputs)
+        fluxes_yg = upwind_fvm(y_gas, boundary_cond=y_gas_inputs)  # [-]
 
-        dygas_dz = np.diff(fluxes_yg, axis=0).T / self.dz
+        dygas_dz = np.diff(fluxes_yg, axis=0).T / self.dz  # [1/m]
 
-        convection = -u_gas * dygas_dz / epsilon_gas
+        convection = -u_gas * dygas_dz / epsilon_gas  # [1/s]
         # Transfer term
-        transfer_gas = dry_rate.T / epsilon_gas / dens_gas/ (1 - satur)
+        transfer_gas = dry_rate.T / epsilon_gas / dens_gas / \
+            (1 - satur)  # [1/s]
         # Dynamic saturation correction term
-        total_mass_correction = y_gas.T / (1 - satur) * dsat_dt
+        total_mass_correction = y_gas.T / (1 - satur) * dsat_dt  # [1/s]
 
-        dygas_dt = convection + transfer_gas + total_mass_correction
+        dygas_dt = convection + transfer_gas + total_mass_correction  # [1/s]
 
         if return_terms:    # TODO: check term by term in material balance down this line
             self.masstrans_comp = 1

--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -217,15 +217,26 @@ class Drying:
         return dry_rates
 
     def _drying_rate_mass_basis(self, dry_rate):
-        """Convert molar drying rates [mol/m**3/s] to mass rates [kg/m**3/s]."""
+        """Convert molar drying rates to mass rates.
+
+        Parameters
+        ----------
+        dry_rate : ndarray
+            Component drying rates on a molar basis [mol/m**3/s].
+
+        Returns
+        -------
+        ndarray
+            Component drying rates on a mass basis [kg/m**3/s].
+        """
         mw = np.asarray(self.Liquid_1.mw) / 1000  # [kg/mol]
 
         return dry_rate * mw
 
     def unit_model(self, time, states, sw=None):
-        '''
+        """
         state vector in the order: S|w_gas|w_liq|Tg|Ts
-        '''
+        """
 
         num_comp = self.Liquid_1.num_species
         states_reord = states.reshape(-1, 3 + num_comp + self.num_volatiles)
@@ -307,7 +318,7 @@ class Drying:
         # ----- Liquid phase
         dens_liq = self.rho_liq
 
-        dry_rate_volatiles = dry_rate[:, self.idx_volatiles]
+        dry_rate_volatiles = dry_rate[:, self.idx_volatiles]  # [kg/m**3/s]
         sum_dry = dry_rate_volatiles.sum(axis=1)  # [kg/m**3/s]
 
         dsat_dt = -sum_dry / dens_liq / self.porosity

--- a/tests/test_drying_energy_rate_basis.py
+++ b/tests/test_drying_energy_rate_basis.py
@@ -5,7 +5,10 @@ instead of building a complete ``solve_unit`` drying example. That keeps the
 test to a single right-hand-side evaluation while still exercising the real
 ``unit_model -> energy_balance`` path for issue #48. No checked-in PharmaPy
 example currently constructs an end-to-end Drying run from full phase/cake
-classes, so the fixture below documents the assumed state layout and units.
+classes. External class-material examples can seed future integration coverage,
+but a full Drying transient regression is deferred until the open Drying
+correctness issues are resolved; this fixture documents the assumed state layout
+and units for the focused energy-basis path.
 """
 
 from types import SimpleNamespace

--- a/tests/test_drying_energy_rate_basis.py
+++ b/tests/test_drying_energy_rate_basis.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.assimulo
 
 def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     """Energy terms combine mass drying rates with mass-basis heat data."""
-    dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer = Drying(number_nodes=3, supercrit_names=["nitrogen"])
     dryer.num_volatiles = 2
     dryer.idx_volatiles = np.array([0, 2])
     dryer.idx_supercrit = np.array([1])
@@ -21,8 +21,8 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     dryer.cp_sol = 1000.0  # [J/kg/K]
     dryer.s_inf = 0.1
     dryer.dPg_dz = 2.0
-    dryer.dz = np.ones(2)
-    dryer.pres_gas = np.array([60000.0, 122000.0])  # gives rho_gas [2, 4]
+    dryer.dz = np.ones(3)
+    dryer.pres_gas = np.array([60000.0, 122000.0, 62000.0])
     dryer.CakePhase = SimpleNamespace(alpha=1.2)
     dryer.h_T_j = 0.0
     dryer.a_V = 1.0
@@ -34,12 +34,14 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
         num_species=3,
         mw=np.array([18.0, 28.0, 46.0]),  # [g/mol]
         rho_liq=np.array([800.0, 850.0, 800.0]),  # [kg/m**3]
-        getCp=lambda temp, mass_frac, basis: np.array([2000.0, 2000.0]),
+        getCp=lambda temp, mass_frac, basis: np.array([2000.0, 2000.0, 2000.0]),
     )
     dryer.Vapor_1 = SimpleNamespace(
         mw=np.array([83.14, 83.14, 83.14]),  # [g/mol]
-        getViscosity=lambda temp, mass_frac: np.ones(2),
-        getCp=lambda temp, mass_frac, basis: np.array([1000.0, 1200.0]),
+        getViscosity=lambda temp, mass_frac: np.ones(3),
+        getCp=lambda temp, mass_frac, basis: np.array([1000.0, 1200.0, 1500.0]),
+        # One latent heat value per volatile component; the node count is
+        # intentionally different so this cannot be read as per-node data.
         getHeatVaporization=lambda temp, basis: np.array([2.0e6, 1.0e6]),
     )
     dryer.get_inputs = lambda time: {
@@ -52,6 +54,7 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     molar_dry_rate = np.array([
         [2.0, 0.0, 4.0],
         [3.0, 0.0, 5.0],
+        [1.0, 0.0, 2.0],
     ])  # [mol/m**3/s]
     monkeypatch.setattr(
         dryer,
@@ -67,28 +70,34 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
         dryer,
         "material_balance",
         lambda *args, **kwargs: [
-            np.zeros(2),
-            np.zeros((2, 3)),
-            np.zeros((2, 2)),
+            np.zeros(3),
+            np.zeros((3, 3)),
+            np.zeros((3, 2)),
         ],
     )
 
     states = np.array([
         [0.5, 0.10, 0.80, 0.10, 0.0, 1.0, 300.0, 299.0],
         [0.5, 0.20, 0.70, 0.10, 0.0, 1.0, 305.0, 304.0],
+        [0.5, 0.30, 0.60, 0.10, 0.0, 1.0, 310.0, 309.0],
     ])
 
     derivatives = dryer.unit_model(time=0.0, states=states.ravel())
-    derivatives = derivatives.reshape(2, -1)
+    derivatives = derivatives.reshape(3, -1)
 
     # Sensible power is cp_gas * (T_gas - 295 K) * sum(m_dot_i).
-    expected_gas_temperature_rate = np.array([1100.0 / 450.0, 3408.0 / 1100.0])
+    expected_gas_temperature_rate = np.array([
+        1100.0 / 450.0,
+        3408.0 / 1100.0,
+        2475.0 / 700.0,
+    ])
 
-    # The mass-rate latent powers are [256000, 338000] J/m**3/s. Issue #24
+    # The mass-rate latent powers are [256000, 338000, 128000] J/m**3/s. Issue #24
     # separately tracks the existing factor of two applied to those powers.
     expected_condensed_temperature_rate = np.array([
         -512000.0 / 900000.0,
         -676000.0 / 900000.0,
+        -256000.0 / 900000.0,
     ])
 
     np.testing.assert_allclose(

--- a/tests/test_drying_energy_rate_basis.py
+++ b/tests/test_drying_energy_rate_basis.py
@@ -1,3 +1,13 @@
+"""Drying energy-basis regression coverage.
+
+This file uses a compact synthetic Drying fixture and calls ``unit_model`` once
+instead of building a complete ``solve_unit`` drying example. That keeps the
+test to a single right-hand-side evaluation while still exercising the real
+``unit_model -> energy_balance`` path for issue #48. No checked-in PharmaPy
+example currently constructs an end-to-end Drying run from full phase/cake
+classes, so the fixture below documents the assumed state layout and units.
+"""
+
 from types import SimpleNamespace
 
 import numpy as np
@@ -13,41 +23,49 @@ pytestmark = pytest.mark.assimulo
 def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     """Energy terms combine mass drying rates with mass-basis heat data."""
     dryer = Drying(number_nodes=3, supercrit_names=["nitrogen"])
-    dryer.num_volatiles = 2
-    dryer.idx_volatiles = np.array([0, 2])
-    dryer.idx_supercrit = np.array([1])
-    dryer.porosity = 0.5
+    dryer.num_volatiles = 2  # [-]
+    dryer.idx_volatiles = np.array([0, 2])  # component indices [-]
+    dryer.idx_supercrit = np.array([1])  # component indices [-]
+    dryer.porosity = 0.5  # [-]
     dryer.rho_sol = 1000.0  # [kg/m**3]
     dryer.cp_sol = 1000.0  # [J/kg/K]
-    dryer.s_inf = 0.1
-    dryer.dPg_dz = 2.0
-    dryer.dz = np.ones(3)
-    dryer.pres_gas = np.array([60000.0, 122000.0, 62000.0])
-    dryer.CakePhase = SimpleNamespace(alpha=1.2)
-    dryer.h_T_j = 0.0
-    dryer.a_V = 1.0
-    dryer.h_T_loss = 0.0
-    dryer.cake_height = 1.0
-    dryer.T_ambient = 298.15
+    dryer.s_inf = 0.1  # [-]
+    dryer.dPg_dz = 2.0  # [Pa/m]
+    dryer.dz = np.ones(3)  # [m]
+    dryer.pres_gas = np.array([60000.0, 122000.0, 62000.0])  # [Pa]
+    dryer.CakePhase = SimpleNamespace(alpha=1.2)  # [m/kg]
+    dryer.h_T_j = 0.0  # [W/m**2/K]
+    dryer.a_V = 1.0  # [m**2/m**3]
+    dryer.h_T_loss = 0.0  # [W/m**2/K]
+    dryer.cake_height = 1.0  # [m]
+    dryer.T_ambient = 298.15  # [K]
 
     dryer.Liquid_1 = SimpleNamespace(
-        num_species=3,
+        num_species=3,  # [-]
         mw=np.array([18.0, 28.0, 46.0]),  # [g/mol]
         rho_liq=np.array([800.0, 850.0, 800.0]),  # [kg/m**3]
-        getCp=lambda temp, mass_frac, basis: np.array([2000.0, 2000.0, 2000.0]),
+        getCp=lambda temp, mass_frac, basis: np.array([
+            2000.0,
+            2000.0,
+            2000.0,
+        ]),  # [J/kg/K]
     )
     dryer.Vapor_1 = SimpleNamespace(
         mw=np.array([83.14, 83.14, 83.14]),  # [g/mol]
-        getViscosity=lambda temp, mass_frac: np.ones(3),
-        getCp=lambda temp, mass_frac, basis: np.array([1000.0, 1200.0, 1500.0]),
+        getViscosity=lambda temp, mass_frac: np.ones(3),  # [Pa*s]
+        getCp=lambda temp, mass_frac, basis: np.array([
+            1000.0,
+            1200.0,
+            1500.0,
+        ]),  # [J/kg/K]
         # One latent heat value per volatile component; the node count is
         # intentionally different so this cannot be read as per-node data.
-        getHeatVaporization=lambda temp, basis: np.array([2.0e6, 1.0e6]),
+        getHeatVaporization=lambda temp, basis: np.array([2.0e6, 1.0e6]),  # [J/kg]
     )
     dryer.get_inputs = lambda time: {
         "Inlet": {
-            "mass_frac": np.array([0.05, 0.90, 0.05]),
-            "temp": 300.0,
+            "mass_frac": np.array([0.05, 0.90, 0.05]),  # [-]
+            "temp": 300.0,  # [K]
         }
     }
 
@@ -64,33 +82,36 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     monkeypatch.setattr(
         drying_module,
         "high_resolution_fvm",
-        lambda values, boundary_cond: np.zeros(values.size + 1),
+        lambda values, boundary_cond: np.zeros(values.size + 1),  # [K]
     )
     monkeypatch.setattr(
         dryer,
         "material_balance",
         lambda *args, **kwargs: [
-            np.zeros(3),
-            np.zeros((3, 3)),
-            np.zeros((3, 2)),
+            np.zeros(3),  # saturation derivative [1/s]
+            np.zeros((3, 3)),  # gas mass-fraction derivative [1/s]
+            np.zeros((3, 2)),  # liquid mass-fraction derivative [1/s]
         ],
     )
 
+    # Columns: saturation [-], y_gas [-], x_liq [-], T_gas [K], T_cond [K].
     states = np.array([
         [0.5, 0.10, 0.80, 0.10, 0.0, 1.0, 300.0, 299.0],
         [0.5, 0.20, 0.70, 0.10, 0.0, 1.0, 305.0, 304.0],
         [0.5, 0.30, 0.60, 0.10, 0.0, 1.0, 310.0, 309.0],
     ])
 
+    # State derivatives follow the same layout as states, with time basis [1/s].
     derivatives = dryer.unit_model(time=0.0, states=states.ravel())
     derivatives = derivatives.reshape(3, -1)
 
-    # Sensible power is cp_gas * (T_gas - 295 K) * sum(m_dot_i).
+    # Sensible power [J/m**3/s] divided by gas capacity [J/m**3/K].
+    # power = cp_gas [J/kg/K] * (T_gas - 295 K) * sum(m_dot_i) [kg/m**3/s].
     expected_gas_temperature_rate = np.array([
         1100.0 / 450.0,
         3408.0 / 1100.0,
         2475.0 / 700.0,
-    ])
+    ])  # [K/s]
 
     # The mass-rate latent powers are [256000, 338000, 128000] J/m**3/s. Issue #24
     # separately tracks the existing factor of two applied to those powers.
@@ -98,7 +119,7 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
         -512000.0 / 900000.0,
         -676000.0 / 900000.0,
         -256000.0 / 900000.0,
-    ])
+    ])  # [K/s]
 
     np.testing.assert_allclose(
         derivatives[:, -2], expected_gas_temperature_rate

--- a/tests/test_drying_energy_rate_basis.py
+++ b/tests/test_drying_energy_rate_basis.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("assimulo")
+import PharmaPy.Drying_Model as drying_module
+from PharmaPy.Drying_Model import Drying
+
+pytestmark = pytest.mark.assimulo
+
+
+def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
+    """Energy terms combine mass drying rates with mass-basis heat data."""
+    dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer.num_volatiles = 2
+    dryer.idx_volatiles = np.array([0, 2])
+    dryer.idx_supercrit = np.array([1])
+    dryer.porosity = 0.5
+    dryer.rho_sol = 1000.0  # [kg/m**3]
+    dryer.cp_sol = 1000.0  # [J/kg/K]
+    dryer.s_inf = 0.1
+    dryer.dPg_dz = 2.0
+    dryer.dz = np.ones(2)
+    dryer.pres_gas = np.array([60000.0, 122000.0])  # gives rho_gas [2, 4]
+    dryer.CakePhase = SimpleNamespace(alpha=1.2)
+    dryer.h_T_j = 0.0
+    dryer.a_V = 1.0
+    dryer.h_T_loss = 0.0
+    dryer.cake_height = 1.0
+    dryer.T_ambient = 298.15
+
+    dryer.Liquid_1 = SimpleNamespace(
+        num_species=3,
+        mw=np.array([18.0, 28.0, 46.0]),  # [g/mol]
+        rho_liq=np.array([800.0, 850.0, 800.0]),  # [kg/m**3]
+        getCp=lambda temp, mass_frac, basis: np.array([2000.0, 2000.0]),
+    )
+    dryer.Vapor_1 = SimpleNamespace(
+        mw=np.array([83.14, 83.14, 83.14]),  # [g/mol]
+        getViscosity=lambda temp, mass_frac: np.ones(2),
+        getCp=lambda temp, mass_frac, basis: np.array([1000.0, 1200.0]),
+        getHeatVaporization=lambda temp, basis: np.array([2.0e6, 1.0e6]),
+    )
+    dryer.get_inputs = lambda time: {
+        "Inlet": {
+            "mass_frac": np.array([0.05, 0.90, 0.05]),
+            "temp": 300.0,
+        }
+    }
+
+    molar_dry_rate = np.array([
+        [2.0, 0.0, 4.0],
+        [3.0, 0.0, 5.0],
+    ])  # [mol/m**3/s]
+    monkeypatch.setattr(
+        dryer,
+        "get_drying_rate",
+        lambda x_liq, temp_sol, y_gas, pres_gas: molar_dry_rate,
+    )
+    monkeypatch.setattr(
+        drying_module,
+        "high_resolution_fvm",
+        lambda values, boundary_cond: np.zeros(values.size + 1),
+    )
+    monkeypatch.setattr(
+        dryer,
+        "material_balance",
+        lambda *args, **kwargs: [
+            np.zeros(2),
+            np.zeros((2, 3)),
+            np.zeros((2, 2)),
+        ],
+    )
+
+    states = np.array([
+        [0.5, 0.10, 0.80, 0.10, 0.0, 1.0, 300.0, 299.0],
+        [0.5, 0.20, 0.70, 0.10, 0.0, 1.0, 305.0, 304.0],
+    ])
+
+    derivatives = dryer.unit_model(time=0.0, states=states.ravel())
+    derivatives = derivatives.reshape(2, -1)
+
+    # Sensible power is cp_gas * (T_gas - 295 K) * sum(m_dot_i).
+    expected_gas_temperature_rate = np.array([1100.0 / 450.0, 3408.0 / 1100.0])
+
+    # The mass-rate latent powers are [256000, 338000] J/m**3/s. Issue #24
+    # separately tracks the existing factor of two applied to those powers.
+    expected_condensed_temperature_rate = np.array([
+        -512000.0 / 900000.0,
+        -676000.0 / 900000.0,
+    ])
+
+    np.testing.assert_allclose(
+        derivatives[:, -2], expected_gas_temperature_rate
+    )
+    np.testing.assert_allclose(
+        derivatives[:, -1], expected_condensed_temperature_rate
+    )

--- a/tests/test_drying_model.py
+++ b/tests/test_drying_model.py
@@ -1,3 +1,10 @@
+"""Assimulo-marked regressions for drying-rate unit contracts.
+
+The fixtures are intentionally small, made-up drying states. They isolate the
+molar-to-mass drying-rate conversion and the downstream material-balance terms
+without running an end-to-end drying simulation.
+"""
+
 from types import SimpleNamespace
 
 import numpy as np
@@ -11,47 +18,47 @@ pytestmark = pytest.mark.assimulo
 
 def test_drying_rate_mass_basis_converts_molar_rates_with_component_mw():
     dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
-    dryer.Liquid_1 = SimpleNamespace(mw=np.array([18.0, 28.0, 46.0]))
+    dryer.Liquid_1 = SimpleNamespace(mw=np.array([18.0, 28.0, 46.0]))  # [g/mol]
     dry_rate = np.array([
         [2.0, 0.0, 4.0],
         [3.0, 0.0, 5.0],
-    ])
+    ])  # [mol/m**3/s]
 
     dry_rate_mass = dryer._drying_rate_mass_basis(dry_rate)
 
     expected = np.array([
         [0.036, 0.0, 0.184],
         [0.054, 0.0, 0.230],
-    ])
+    ])  # [kg/m**3/s]
     np.testing.assert_allclose(dry_rate_mass, expected)
 
 
 def test_material_balance_uses_mass_drying_rate_for_saturation():
     dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
-    dryer.idx_volatiles = np.array([0, 2])
-    dryer.porosity = 0.4
-    dryer.rho_liq = np.array([800.0, 900.0])
-    dryer.dz = np.ones(2)
-    dryer.Liquid_1 = SimpleNamespace(mw=np.array([18.0, 28.0, 46.0]))
+    dryer.idx_volatiles = np.array([0, 2])  # [-]
+    dryer.porosity = 0.4  # [-]
+    dryer.rho_liq = np.array([800.0, 900.0])  # [kg/m**3]
+    dryer.dz = np.ones(2)  # [m]
+    dryer.Liquid_1 = SimpleNamespace(mw=np.array([18.0, 28.0, 46.0]))  # [g/mol]
 
-    satur = np.array([0.6, 0.8])
-    temp_gas = np.array([300.0, 305.0])
-    temp_sol = np.array([299.0, 304.0])
+    satur = np.array([0.6, 0.8])  # [-]
+    temp_gas = np.array([300.0, 305.0])  # [K]
+    temp_sol = np.array([299.0, 304.0])  # [K]
     y_gas = np.array([
         [0.02, 0.96, 0.02],
         [0.03, 0.94, 0.03],
-    ])
+    ])  # [-]
     x_liq = np.array([
         [0.25, 0.75],
         [0.40, 0.60],
-    ])
-    u_gas = np.zeros(2)
-    dens_gas = np.ones(2)
+    ])  # [-]
+    u_gas = np.zeros(2)  # [m/s]
+    dens_gas = np.ones(2)  # [kg/m**3]
     dry_rate = np.array([
         [0.036, 0.0, 0.184],
         [0.054, 0.0, 0.230],
-    ])
-    inputs = {"mass_frac": np.array([0.01, 0.98, 0.01])}
+    ])  # [kg/m**3/s]
+    inputs = {"mass_frac": np.array([0.01, 0.98, 0.01])}  # [-]
 
     dsat_dt, _, _ = dryer.material_balance(
         time=0.0,
@@ -66,59 +73,59 @@ def test_material_balance_uses_mass_drying_rate_for_saturation():
         inputs=inputs,
     )
 
-    mass_rate = np.array([0.22, 0.284])
-    expected_dsat_dt = -mass_rate / dryer.rho_liq / dryer.porosity
+    mass_rate = np.array([0.22, 0.284])  # [kg/m**3/s]
+    expected_dsat_dt = -mass_rate / dryer.rho_liq / dryer.porosity  # [1/s]
 
     np.testing.assert_allclose(dsat_dt, expected_dsat_dt)
 
 
 def test_unit_model_converts_drying_rate_before_balance_equations(monkeypatch):
     dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
-    dryer.num_volatiles = 2
-    dryer.idx_volatiles = np.array([0, 2])
-    dryer.idx_supercrit = np.array([1])
-    dryer.porosity = 0.5
-    dryer.rho_sol = 1500.0
-    dryer.s_inf = 0.1
-    dryer.dPg_dz = 2.0
-    dryer.pres_gas = np.array([101325.0, 101000.0])
-    dryer.CakePhase = SimpleNamespace(alpha=1.2)
+    dryer.num_volatiles = 2  # [-]
+    dryer.idx_volatiles = np.array([0, 2])  # [-]
+    dryer.idx_supercrit = np.array([1])  # [-]
+    dryer.porosity = 0.5  # [-]
+    dryer.rho_sol = 1500.0  # [kg/m**3]
+    dryer.s_inf = 0.1  # [-]
+    dryer.dPg_dz = 2.0  # [Pa/m]
+    dryer.pres_gas = np.array([101325.0, 101000.0])  # [Pa]
+    dryer.CakePhase = SimpleNamespace(alpha=1.2)  # [m/kg]
     dryer.Liquid_1 = SimpleNamespace(
-        num_species=3,
-        mw=np.array([18.0, 28.0, 46.0]),
-        rho_liq=np.array([800.0, 850.0, 900.0]),
+        num_species=3,  # [-]
+        mw=np.array([18.0, 28.0, 46.0]),  # [g/mol]
+        rho_liq=np.array([800.0, 850.0, 900.0]),  # [kg/m**3]
     )
     dryer.Vapor_1 = SimpleNamespace(
-        mw=np.array([18.0, 28.0, 46.0]),
-        getViscosity=lambda temp, mass_frac: np.ones(2),
+        mw=np.array([18.0, 28.0, 46.0]),  # [g/mol]
+        getViscosity=lambda temp, mass_frac: np.ones(2),  # [Pa*s]
     )
     dryer.get_inputs = lambda time: {
         "Inlet": {"mass_frac": np.array([0.05, 0.90, 0.05])}
-    }
+    }  # [-]
 
     molar_dry_rate = np.array([
         [2.0, 0.0, 4.0],
         [3.0, 0.0, 5.0],
-    ])
+    ])  # [mol/m**3/s]
     expected_mass_rate = np.array([
         [0.036, 0.0, 0.184],
         [0.054, 0.0, 0.230],
-    ])
+    ])  # [kg/m**3/s]
     monkeypatch.setattr(
         dryer,
         "get_drying_rate",
         lambda x_liq, temp_sol, y_gas, pres_gas: molar_dry_rate,
     )
 
-    captured = {}
+    captured = {}  # [-]
 
     def material_balance(*args, **kwargs):
-        captured["material_dry_rate"] = args[8].copy()
-        return [np.zeros(2), np.zeros((2, 3)), np.zeros((2, 2))]
+        captured["material_dry_rate"] = args[8].copy()  # [kg/m**3/s]
+        return [np.zeros(2), np.zeros((2, 3)), np.zeros((2, 2))]  # [1/s]
 
     def energy_balance(*args, **kwargs):
-        captured["energy_dry_rate"] = args[8].copy()
-        return [np.zeros(2), np.zeros(2)]
+        captured["energy_dry_rate"] = args[8].copy()  # [kg/m**3/s]
+        return [np.zeros(2), np.zeros(2)]  # [K/s]
 
     monkeypatch.setattr(dryer, "material_balance", material_balance)
     monkeypatch.setattr(dryer, "energy_balance", energy_balance)
@@ -126,7 +133,7 @@ def test_unit_model_converts_drying_rate_before_balance_equations(monkeypatch):
     states = np.array([
         [0.6, 0.10, 0.80, 0.10, 0.55, 0.45, 300.0, 299.0],
         [0.7, 0.20, 0.70, 0.10, 0.60, 0.40, 301.0, 300.0],
-    ])
+    ])  # S [-], w_gas [-], w_liq [-], Tg [K], Ts [K]
 
     model_eqns = dryer.unit_model(time=0.0, states=states.ravel())
 
@@ -138,29 +145,29 @@ def test_unit_model_converts_drying_rate_before_balance_equations(monkeypatch):
 
 def test_material_balance_uses_mass_drying_rate_for_gas_species():
     dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
-    dryer.idx_volatiles = np.array([0, 2])
-    dryer.porosity = 0.5
-    dryer.rho_liq = np.array([1000.0, 1000.0])
-    dryer.dz = np.ones(2)
+    dryer.idx_volatiles = np.array([0, 2])  # [-]
+    dryer.porosity = 0.5  # [-]
+    dryer.rho_liq = np.array([1000.0, 1000.0])  # [kg/m**3]
+    dryer.dz = np.ones(2)  # [m]
 
-    satur = np.array([0.5, 0.5])
-    temp_gas = np.array([300.0, 300.0])
-    temp_sol = np.array([299.0, 299.0])
+    satur = np.array([0.5, 0.5])  # [-]
+    temp_gas = np.array([300.0, 300.0])  # [K]
+    temp_sol = np.array([299.0, 299.0])  # [K]
     y_gas = np.array([
         [0.10, 0.80, 0.10],
         [0.20, 0.70, 0.10],
-    ])
+    ])  # [-]
     x_liq = np.array([
         [0.50, 0.50],
         [0.50, 0.50],
-    ])
-    u_gas = np.zeros(2)
-    dens_gas = np.array([1.2, 1.5])
+    ])  # [-]
+    u_gas = np.zeros(2)  # [m/s]
+    dens_gas = np.array([1.2, 1.5])  # [kg/m**3]
     dry_rate = np.array([
         [0.036, 0.0, 0.184],
         [0.054, 0.0, 0.230],
-    ])
-    inputs = {"mass_frac": np.array([0.05, 0.90, 0.05])}
+    ])  # [kg/m**3/s]
+    inputs = {"mass_frac": np.array([0.05, 0.90, 0.05])}  # [-]
 
     dsat_dt, dygas_dt, _ = dryer.material_balance(
         time=0.0,
@@ -178,6 +185,6 @@ def test_material_balance_uses_mass_drying_rate_for_gas_species():
     expected_dygas_dt = np.array([
         [0.239912, -0.000704, 1.2265786666666665],
         [0.2877728, -0.0007952, 1.2265530666666665],
-    ])
+    ])  # [1/s]
 
     np.testing.assert_allclose(dygas_dt, expected_dygas_dt)

--- a/tests/test_drying_model.py
+++ b/tests/test_drying_model.py
@@ -24,7 +24,7 @@ def test_drying_rate_mass_basis_converts_molar_rates_with_component_mw():
         [3.0, 0.0, 5.0],
     ])  # [mol/m**3/s]
 
-    dry_rate_mass = dryer._drying_rate_mass_basis(dry_rate)
+    dry_rate_mass = dryer._drying_rate_mass_basis(dry_rate)  # [kg/m**3/s]
 
     expected = np.array([
         [0.036, 0.0, 0.184],
@@ -71,7 +71,7 @@ def test_material_balance_uses_mass_drying_rate_for_saturation():
         dens_gas=dens_gas,
         dry_rate=dry_rate,
         inputs=inputs,
-    )
+    )  # [1/s]
 
     mass_rate = np.array([0.22, 0.284])  # [kg/m**3/s]
     expected_dsat_dt = -mass_rate / dryer.rho_liq / dryer.porosity  # [1/s]
@@ -135,7 +135,7 @@ def test_unit_model_converts_drying_rate_before_balance_equations(monkeypatch):
         [0.7, 0.20, 0.70, 0.10, 0.60, 0.40, 301.0, 300.0],
     ])  # S [-], w_gas [-], w_liq [-], Tg [K], Ts [K]
 
-    model_eqns = dryer.unit_model(time=0.0, states=states.ravel())
+    model_eqns = dryer.unit_model(time=0.0, states=states.ravel())  # [1/s] and [K/s]
 
     np.testing.assert_allclose(captured["material_dry_rate"], expected_mass_rate)
     np.testing.assert_allclose(captured["energy_dry_rate"], expected_mass_rate)
@@ -180,7 +180,7 @@ def test_material_balance_uses_mass_drying_rate_for_gas_species():
         dens_gas=dens_gas,
         dry_rate=dry_rate,
         inputs=inputs,
-    )
+    )  # [1/s]
 
     expected_dygas_dt = np.array([
         [0.239912, -0.000704, 1.2265786666666665],

--- a/tests/test_drying_model.py
+++ b/tests/test_drying_model.py
@@ -72,6 +72,70 @@ def test_material_balance_uses_mass_drying_rate_for_saturation():
     np.testing.assert_allclose(dsat_dt, expected_dsat_dt)
 
 
+def test_unit_model_converts_drying_rate_before_balance_equations(monkeypatch):
+    dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer.num_volatiles = 2
+    dryer.idx_volatiles = np.array([0, 2])
+    dryer.idx_supercrit = np.array([1])
+    dryer.porosity = 0.5
+    dryer.rho_sol = 1500.0
+    dryer.s_inf = 0.1
+    dryer.dPg_dz = 2.0
+    dryer.pres_gas = np.array([101325.0, 101000.0])
+    dryer.CakePhase = SimpleNamespace(alpha=1.2)
+    dryer.Liquid_1 = SimpleNamespace(
+        num_species=3,
+        mw=np.array([18.0, 28.0, 46.0]),
+        rho_liq=np.array([800.0, 850.0, 900.0]),
+    )
+    dryer.Vapor_1 = SimpleNamespace(
+        mw=np.array([18.0, 28.0, 46.0]),
+        getViscosity=lambda temp, mass_frac: np.ones(2),
+    )
+    dryer.get_inputs = lambda time: {
+        "Inlet": {"mass_frac": np.array([0.05, 0.90, 0.05])}
+    }
+
+    molar_dry_rate = np.array([
+        [2.0, 0.0, 4.0],
+        [3.0, 0.0, 5.0],
+    ])
+    expected_mass_rate = np.array([
+        [0.036, 0.0, 0.184],
+        [0.054, 0.0, 0.230],
+    ])
+    monkeypatch.setattr(
+        dryer,
+        "get_drying_rate",
+        lambda x_liq, temp_sol, y_gas, pres_gas: molar_dry_rate,
+    )
+
+    captured = {}
+
+    def material_balance(*args, **kwargs):
+        captured["material_dry_rate"] = args[8].copy()
+        return [np.zeros(2), np.zeros((2, 3)), np.zeros((2, 2))]
+
+    def energy_balance(*args, **kwargs):
+        captured["energy_dry_rate"] = args[8].copy()
+        return [np.zeros(2), np.zeros(2)]
+
+    monkeypatch.setattr(dryer, "material_balance", material_balance)
+    monkeypatch.setattr(dryer, "energy_balance", energy_balance)
+
+    states = np.array([
+        [0.6, 0.10, 0.80, 0.10, 0.55, 0.45, 300.0, 299.0],
+        [0.7, 0.20, 0.70, 0.10, 0.60, 0.40, 301.0, 300.0],
+    ])
+
+    model_eqns = dryer.unit_model(time=0.0, states=states.ravel())
+
+    np.testing.assert_allclose(captured["material_dry_rate"], expected_mass_rate)
+    np.testing.assert_allclose(captured["energy_dry_rate"], expected_mass_rate)
+    np.testing.assert_allclose(dryer.dry_rate, expected_mass_rate)
+    np.testing.assert_allclose(model_eqns, np.zeros(states.size))
+
+
 def test_material_balance_uses_mass_drying_rate_for_gas_species():
     dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
     dryer.idx_volatiles = np.array([0, 2])
@@ -111,12 +175,9 @@ def test_material_balance_uses_mass_drying_rate_for_gas_species():
         inputs=inputs,
     )
 
-    epsilon_gas = dryer.porosity * (1 - satur)
-    transfer_gas = (
-        dry_rate / epsilon_gas[:, np.newaxis] / dens_gas[:, np.newaxis] /
-        (1 - satur)[:, np.newaxis]
-    )
-    correction = y_gas / (1 - satur)[:, np.newaxis] * dsat_dt[:, np.newaxis]
-    expected_dygas_dt = transfer_gas + correction
+    expected_dygas_dt = np.array([
+        [0.239912, -0.000704, 1.2265786666666665],
+        [0.2877728, -0.0007952, 1.2265530666666665],
+    ])
 
     np.testing.assert_allclose(dygas_dt, expected_dygas_dt)

--- a/tests/test_drying_model.py
+++ b/tests/test_drying_model.py
@@ -9,7 +9,24 @@ from PharmaPy.Drying_Model import Drying
 pytestmark = pytest.mark.assimulo
 
 
-def test_material_balance_converts_molar_drying_rate_to_mass_for_saturation():
+def test_drying_rate_mass_basis_converts_molar_rates_with_component_mw():
+    dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer.Liquid_1 = SimpleNamespace(mw=np.array([18.0, 28.0, 46.0]))
+    dry_rate = np.array([
+        [2.0, 0.0, 4.0],
+        [3.0, 0.0, 5.0],
+    ])
+
+    dry_rate_mass = dryer._drying_rate_mass_basis(dry_rate)
+
+    expected = np.array([
+        [0.036, 0.0, 0.184],
+        [0.054, 0.0, 0.230],
+    ])
+    np.testing.assert_allclose(dry_rate_mass, expected)
+
+
+def test_material_balance_uses_mass_drying_rate_for_saturation():
     dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
     dryer.idx_volatiles = np.array([0, 2])
     dryer.porosity = 0.4
@@ -31,8 +48,8 @@ def test_material_balance_converts_molar_drying_rate_to_mass_for_saturation():
     u_gas = np.zeros(2)
     dens_gas = np.ones(2)
     dry_rate = np.array([
-        [2.0, 0.0, 4.0],
-        [3.0, 0.0, 5.0],
+        [0.036, 0.0, 0.184],
+        [0.054, 0.0, 0.230],
     ])
     inputs = {"mass_frac": np.array([0.01, 0.98, 0.01])}
 
@@ -53,3 +70,53 @@ def test_material_balance_converts_molar_drying_rate_to_mass_for_saturation():
     expected_dsat_dt = -mass_rate / dryer.rho_liq / dryer.porosity
 
     np.testing.assert_allclose(dsat_dt, expected_dsat_dt)
+
+
+def test_material_balance_uses_mass_drying_rate_for_gas_species():
+    dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer.idx_volatiles = np.array([0, 2])
+    dryer.porosity = 0.5
+    dryer.rho_liq = np.array([1000.0, 1000.0])
+    dryer.dz = np.ones(2)
+
+    satur = np.array([0.5, 0.5])
+    temp_gas = np.array([300.0, 300.0])
+    temp_sol = np.array([299.0, 299.0])
+    y_gas = np.array([
+        [0.10, 0.80, 0.10],
+        [0.20, 0.70, 0.10],
+    ])
+    x_liq = np.array([
+        [0.50, 0.50],
+        [0.50, 0.50],
+    ])
+    u_gas = np.zeros(2)
+    dens_gas = np.array([1.2, 1.5])
+    dry_rate = np.array([
+        [0.036, 0.0, 0.184],
+        [0.054, 0.0, 0.230],
+    ])
+    inputs = {"mass_frac": np.array([0.05, 0.90, 0.05])}
+
+    dsat_dt, dygas_dt, _ = dryer.material_balance(
+        time=0.0,
+        satur=satur,
+        temp_gas=temp_gas,
+        temp_sol=temp_sol,
+        y_gas=y_gas,
+        x_liq=x_liq,
+        u_gas=u_gas,
+        dens_gas=dens_gas,
+        dry_rate=dry_rate,
+        inputs=inputs,
+    )
+
+    epsilon_gas = dryer.porosity * (1 - satur)
+    transfer_gas = (
+        dry_rate / epsilon_gas[:, np.newaxis] / dens_gas[:, np.newaxis] /
+        (1 - satur)[:, np.newaxis]
+    )
+    correction = y_gas / (1 - satur)[:, np.newaxis] * dsat_dt[:, np.newaxis]
+    expected_dygas_dt = transfer_gas + correction
+
+    np.testing.assert_allclose(dygas_dt, expected_dygas_dt)


### PR DESCRIPTION
## Summary

- Convert drying rates from molar to mass basis once in `unit_model` after `get_drying_rate`.
- Reuse that mass-basis rate in the liquid saturation/composition balance and gas species transfer term.
- Add drying model regressions for the conversion, saturation balance, and gas species source term.
- Document the molar/mass-basis contract and inline material-balance units.

Closes #21.
Refs #17, #20, #24, #48, #103.

## Unit Contract

- `get_drying_rate` returns component volumetric drying rates on a molar basis `[mol/m**3/s]`.
- `unit_model` converts that rate once using molecular weights `[kg/mol]`; after `_drying_rate_mass_basis`, `self.dry_rate` is `[kg/m**3/s]`.
- `material_balance` consumes mass-basis drying rates `[kg/m**3/s]`; saturation, gas mass fractions, liquid mass fractions, porosity, and gas holdup terms are dimensionless `[-]`.
- The material-balance derivatives remain `dsat_dt`, `dygas_dt`, and `dxliq_dt` in `[1/s]`.
- `energy_balance` now receives the same mass-basis `self.dry_rate`, which is the shared conversion needed by #48, but #48 still needs energy-specific validation before it can close.

## Coordination Notes

- #21 is part of the #17 model-correctness audit.
- #20 was closed by PR #103 with a local `dry_rate_mass` conversion inside `material_balance`. This PR intentionally removes that local conversion and replaces it with one shared conversion point in `unit_model`, so the #20 saturation fix is preserved without a double MW/1000 conversion.
- `get_drying_rate` remains the molar volumetric-rate calculator (`mol m^-3 s^-1`), matching `k_y * a_V * delta_y`. This PR converts its output once before the model balances consume it.
- #48 has the same molar-vs-mass root cause in `energy_balance`. Because `energy_balance` receives the converted `self.dry_rate`, this PR covers the shared MW/1000 conversion needed by #48. It does not close #48 because that issue still needs energy-specific validation.
- #24 is separate from the mass-basis conversion: it tracks the unrelated latent-heat `* 2` factor in the same energy expression. #48/#24 should be resolved with a clear follow-up diff, likely by removing the `* 2` and adding an isolated energy-balance regression.
- This PR now documents the units contract for `get_drying_rate`, `unit_model`, and `material_balance`; final energy-balance unit validation remains pending #48/#24.

## Tests

- `conda run -n pharmapy python -m pytest tests/test_drying_model.py -q`
- `conda run -n pharmapy python -m pytest tests/ -m "not assimulo" -q`
- `conda run -n pharmapy python -m pytest tests/ -q`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check`

## Branch Hygiene

- Base branch: `master`
- Source branch point: `origin/master`
- Stacked status: not stacked
- Prerequisites: none
