### PR TITLE
Fix Assimulo pip extra metadata

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,14 +2,17 @@
 
 The default install keeps only the core runtime dependencies. Assimulo is an
 optional solver dependency because it is difficult to build on common pip-only
-environments and is only needed for the solver-backed unit-operation models.
+environments, is not published on PyPI above version 3.0, and is only needed for
+the solver-backed unit-operation models. Use the conda-forge environment in
+`environment.yml`, or a local source build of Assimulo, for solver-backed runs.
 
 Current bounds:
 
 `pyproject.toml` is the source of truth for install metadata. The
 `requirements.txt` and `requirements-assimulo.txt` files are convenience
 mirrors for pip-based workflows and should stay synchronized with
-`[project.dependencies]` and the `assimulo` optional extra.
+`[project.dependencies]` and the pip-installable entries in the `assimulo`
+optional extra.
 
 - `numpy>=1.22`: the lower bound gives a modern baseline for supported Python
   versions while allowing the NumPy 2 line to be exercised by CI and Dependabot.
@@ -18,7 +21,11 @@ mirrors for pip-based workflows and should stay synchronized with
   `scipy.integrate.simpson`, so current SciPy releases can be tested directly.
 - `matplotlib>=3.5` and `pandas>=1.5`: lower bounds avoid unbounded old
   releases while leaving current releases open for Dependabot and CI.
-- `cython>=0.29,<3` and `assimulo==3.4.3`: these are confined to the
-  `assimulo` optional extra until the Assimulo integration job proves a broader
-  solver stack works. Dependabot intentionally ignores Assimulo updates and
-  Cython major-version updates until that broader solver stack is verified.
+- `cython>=0.29,<3`: kept in the `assimulo` optional extra as a pip-installable
+  build helper for source-install workflows. The extra does not install
+  Assimulo itself.
+- `assimulo==3.4.3`: the supported Assimulo version for the conda-forge
+  environment and source-build workflows. It is documented here instead of
+  pinned in pip metadata because that release is not available from PyPI.
+  Dependabot intentionally ignores Assimulo updates and Cython major-version
+  updates until a broader solver stack is verified.

--- a/TESTING.md
+++ b/TESTING.md
@@ -17,6 +17,10 @@ python -m pip install -e . --no-deps
 python -m pytest tests/ -v -m assimulo
 ```
 
+`python -m pip install -e ".[assimulo]"` installs only pip-available build
+helpers for source workflows; it does not install Assimulo itself. Use the
+conda environment above for the supported Assimulo test path.
+
 The GitHub Actions Assimulo job is intentionally informational at first. It
 uses `continue-on-error: true` so failures in the external solver stack do not
 block the core test job while the environment is stabilized.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
 [project.optional-dependencies]
 assimulo = [
     "cython>=0.29,<3",
-    "assimulo==3.4.3",
 ]
 test = [
     "pytest",

--- a/requirements-assimulo.txt
+++ b/requirements-assimulo.txt
@@ -1,4 +1,3 @@
 # Optional solver stack for Assimulo-backed models and integration tests.
 -r requirements.txt
 cython>=0.29,<3
-assimulo==3.4.3


### PR DESCRIPTION
Closes #109.

## Summary

- Remove the unresolvable `assimulo==3.4.3` PyPI requirement from the `assimulo` optional extra and `requirements-assimulo.txt`.
- Keep `cython>=0.29,<3` as the pip-installable helper for source-build workflows.
- Document that Assimulo itself is supported through the conda-forge environment or a local source build, not through PyPI.

Related: #8 is packaging-modernization context only; this PR does not depend on it.

## Validation

- `uv pip install -e '.[assimulo]' --dry-run --python .venv/bin/python --cache-dir /tmp/pharmapy-uv-cache-issue109`
- `uv pip install -r requirements-assimulo.txt --dry-run --python .venv/bin/python --cache-dir /tmp/pharmapy-uv-cache-issue109`
- `.venv/bin/python -m pytest --collect-only`
- `.venv/bin/python -m pytest tests/ -m 'not assimulo'`
- `git diff --check`

## Branch Hygiene

- Base branch: `master`
- Branch point: `origin/master@1a3ab3155216f07e9a18c60687a7b6b1c5959202`
- Source branch: `fix/issue-109-assimulo-extra`
- Stacked status: not stacked; no prerequisite PRs
- Upstream status: `upstream/master@400e1e13ad4ecd3ba202d5fae8c70ec73bdf9c3e` is an ancestor of `origin/master`
- Open PR overlap: none found; open PRs #102 and #106-#108 touch source/test files unrelated to this packaging/docs change
