### PR TITLE
Fix kinetics custom params and equilibrium indexing

### DIFF
--- a/PharmaPy/Kinetics.py
+++ b/PharmaPy/Kinetics.py
@@ -356,11 +356,15 @@ class RxnKinetics:
                     orders = orders[np.newaxis, ...]
 
                 params_f = orders
-            elif params_f is None:
-                raise RuntimeError("For user-defined kinetic function, "
-                                   "argument 'params_f' is mandatory.")
+            else:
+                params_f = params.get('params_f', None)
+                if params_f is None:
+                    raise RuntimeError("For user-defined kinetic function, "
+                                       "argument 'params_f' is mandatory.")
+                params_f = np.asarray(params_f)
+                self.params_f_shape = params_f.shape
 
-            self.params_f = orders
+            self.params_f = params_f
             self.order_map = self.stoich_matrix < 0
 
         else:
@@ -373,6 +377,9 @@ class RxnKinetics:
                                                   dtype=np.float64)
 
                     self.params_f[self.order_map] = params[self.num_paramsk:]
+            else:
+                params_f = np.asarray(params[self.num_paramsk:])
+                self.params_f = params_f.reshape(self.params_f_shape)
 
     def nomenclature(self, stoich_matrix, kvals):
 
@@ -387,9 +394,14 @@ class RxnKinetics:
             name_e = ['E_{a, %i}' % ind for ind in range(1, num_kpar + 1)]
 
         if self.fit_paramsf:
-            num_orders = (stoich_matrix < 0).sum()
-            name_orders = [r'\alpha_{}'.format(ind)
-                           for ind in range(1, num_orders + 1)]
+            if self.elem_flag:
+                num_orders = (stoich_matrix < 0).sum()
+                name_orders = [r'\alpha_{}'.format(ind)
+                               for ind in range(1, num_orders + 1)]
+            else:
+                num_orders = np.asarray(self.params_f).size
+                name_orders = [r'\theta_{f,%i}' % ind
+                               for ind in range(1, num_orders + 1)]
         else:
             name_orders = []
 
@@ -424,7 +436,8 @@ class RxnKinetics:
                 params_concat = params_k_conc
 
         else:
-            params_concat = np.concatenate((params_k_conc, self.params_f))
+            params_concat = np.concatenate(
+                (params_k_conc, np.asarray(self.params_f).ravel()))
 
         return params_concat
 
@@ -452,13 +465,18 @@ class RxnKinetics:
 
     def equil_term(self, temp, deltah_temp):
         temp = np.asarray(temp)
+        deltah_temp = np.asarray(deltah_temp)
         inv_temp = (1/temp - 1/self.tref_hrxn)
 
         if temp.ndim == 0:
             k_eq = self.keq_params * np.exp(-deltah_temp/gas_ct * inv_temp)
         else:
-            k_eq = self.keq_params * \
-                np.exp(-np.outer(inv_temp, deltah_temp/gas_ct))
+            if deltah_temp.ndim <= 1:
+                exponent = np.outer(inv_temp, deltah_temp/gas_ct)
+            else:
+                exponent = inv_temp[:, np.newaxis] * deltah_temp/gas_ct
+
+            k_eq = self.keq_params * np.exp(-exponent)
 
         return k_eq
 
@@ -523,8 +541,13 @@ class RxnKinetics:
         else:
             r_term = np.zeros((n_conc, self.num_rxns))
             for ind in range(self.num_rxns):
+                if keq_temp.ndim == 1:
+                    keq_rxn = keq_temp[ind]
+                else:
+                    keq_rxn = keq_temp[:, ind]
+
                 r_term[:, ind] = np.prod(
-                    conc**(orders[ind]), axis=1) / keq_temp[ind]
+                    conc**(orders[ind]), axis=1) / keq_rxn
 
         overall_rate = f_term - r_term
 

--- a/tests/test_kinetics_custom_and_equilibrium.py
+++ b/tests/test_kinetics_custom_and_equilibrium.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for issue #71.
+
+Two independent RxnKinetics defects, grouped as one kinetics-correctness fix:
+
+1. Constructing ``RxnKinetics`` with a user-defined ``kinetic_model``
+   (``elem_flag=False``) raises ``UnboundLocalError`` in ``set_params``.
+2. The vectorized (array-``temp``) equilibrium reverse term divides by ``Keq``
+   indexed on the time axis instead of the reaction axis, so every time point
+   reuses the first row's ``Keq``.
+
+Both live in ``PharmaPy.Kinetics``, which is pure NumPy (no solver backend),
+so these tests need no assimulo marker.
+"""
+
+import numpy as np
+import pytest
+
+from PharmaPy.Kinetics import RxnKinetics
+
+
+STOICH = [[-1, -1, 1, 0]]          # A + B -> C
+PARTIC = ["A", "B", "C", "solv"]
+
+
+def _db(data_path):
+    return str(data_path["integration"] / "pfr_test_pure_comp.json")
+
+
+def _custom_rate(conc, params_f):
+    conc = np.maximum(1e-15, conc)
+    return np.exp(np.dot(np.log(conc), np.atleast_2d(params_f).T))
+
+
+def test_custom_kinetic_model_constructs(data_path):
+    """Defect 1: the documented custom-rate-law workflow must construct."""
+
+    # Must not raise UnboundLocalError in set_params.
+    kin = RxnKinetics(
+        path=_db(data_path),
+        k_params=[1.0],
+        ea_params=[0.0],
+        stoich_matrix=STOICH,
+        partic_species=PARTIC,
+        kinetic_model=_custom_rate,
+        params_f=np.array([[1.0, 1.0]]),
+    )
+
+    assert kin.elem_flag is False
+    assert kin.kinetic_model is _custom_rate
+    # The user-supplied f-parameters must be stored, not dropped.
+    assert kin.params_f is not None
+    np.testing.assert_allclose(np.asarray(kin.params_f).ravel(), [1.0, 1.0])
+
+
+def test_custom_kinetic_model_requires_params_f(data_path):
+    """Custom rate laws still require explicit f-parameters."""
+    with pytest.raises(RuntimeError, match="params_f"):
+        RxnKinetics(
+            path=_db(data_path),
+            k_params=[1.0],
+            ea_params=[0.0],
+            stoich_matrix=STOICH,
+            partic_species=PARTIC,
+            kinetic_model=_custom_rate,
+            params_f=None,
+        )
+
+
+def test_custom_kinetic_model_flat_set_params_updates_params_f(data_path):
+    """Parameter-estimation vector updates custom model f-parameters."""
+    kin = RxnKinetics(
+        path=_db(data_path),
+        k_params=[1.0],
+        ea_params=[0.0],
+        stoich_matrix=STOICH,
+        partic_species=PARTIC,
+        kinetic_model=_custom_rate,
+        params_f=np.array([[1.0, 1.0]]),
+    )
+
+    params = kin.concat_params()
+    params[-2:] = [2.0, 3.0]
+
+    kin.set_params(params)
+
+    np.testing.assert_allclose(np.asarray(kin.params_f).ravel(), [2.0, 3.0])
+
+
+def test_vectorized_equilibrium_matches_scalar_path(data_path):
+    """Defect 2: array-temp reverse term must use per-reaction Keq.
+
+    Oracle is the trusted scalar-temp / 1-D branch: evaluating each time point
+    separately and stacking must equal the single vectorized 2-D evaluation.
+    """
+    kin = RxnKinetics(
+        path=_db(data_path),
+        k_params=[1.0],
+        ea_params=[0.0],
+        stoich_matrix=STOICH,
+        partic_species=PARTIC,
+        keq_params=[2.0],
+        delta_hrxn=[-5e3],
+        tref_hrxn=298.15,
+    )
+
+    temp = np.array([290.0, 310.0, 330.0])
+    conc = np.array([[1.0, 1.0, 1.0, 1.0],
+                     [2.0, 2.0, 2.0, 2.0],
+                     [0.5, 0.5, 0.5, 0.5]])
+    deltah = np.atleast_1d(-5e3)
+
+    vectorized = np.asarray(kin.equilibrium_model(conc, temp, deltah))
+    per_time = np.array([
+        np.asarray(
+            kin.equilibrium_model(conc[i], float(temp[i]), deltah)
+        ).ravel()
+        for i in range(temp.size)
+    ])
+
+    np.testing.assert_allclose(vectorized.reshape(per_time.shape), per_time)
+
+
+def test_vectorized_equilibrium_accepts_2d_deltah(data_path):
+    """Array-temp equilibrium must accept per-time heat-of-reaction values."""
+    kin = RxnKinetics(
+        path=_db(data_path),
+        k_params=[1.0],
+        ea_params=[0.0],
+        stoich_matrix=STOICH,
+        partic_species=PARTIC,
+        keq_params=[2.0],
+        delta_hrxn=[-5e3],
+        tref_hrxn=298.15,
+    )
+
+    temp = np.array([290.0, 310.0, 330.0])
+    conc = np.array([[1.0, 1.0, 1.0, 1.0],
+                     [2.0, 2.0, 2.0, 2.0],
+                     [0.5, 0.5, 0.5, 0.5]])
+    deltah = np.array([[-5.0e3], [-4.5e3], [-4.0e3]])
+
+    vectorized = np.asarray(kin.equilibrium_model(conc, temp, deltah))
+    per_time = np.array([
+        np.asarray(
+            kin.equilibrium_model(conc[i], float(temp[i]), deltah[i])
+        ).ravel()
+        for i in range(temp.size)
+    ])
+
+    np.testing.assert_allclose(vectorized.reshape(per_time.shape), per_time)


### PR DESCRIPTION
## Summary
- Fix `RxnKinetics.set_params` so user-defined `kinetic_model` instances require, store, flatten, and restore custom `params_f` correctly.
- Fix vectorized reversible equilibrium rates so array-temperature reverse terms divide by per-time/per-reaction `Keq` values.
- Add regression coverage for the issue #71 custom-model and vectorized-equilibrium failures.

Closes #71.

## Triage / Acceptance Criteria
Uses the maintainer triage artifact at https://github.com/SECQUOIA/PharmaPy/issues/71#issuecomment-4937212711.

Covered:
- Custom `RxnKinetics(..., kinetic_model=fn, params_f=arr)` constructs and stores the f-parameters.
- Missing custom `params_f` still raises the intended `RuntimeError`.
- Flat parameter-vector updates preserve custom `params_f` shape and update values.
- Vectorized array-temperature `equilibrium_model` matches scalar per-time evaluation.
- 2-D `deltah_rxn` from heat-of-reaction style inputs no longer goes through `np.outer` flattening.

## Related Issues
- #36, #23, and #44 are adjacent kinetics defects called out by the issue, but are not duplicates of this fix and are intentionally left to their own scopes.

## Tests
- Red first: `.venv/bin/python -m pytest tests/test_kinetics_custom_and_equilibrium.py -v` failed on unchanged base with the recorded custom-model `UnboundLocalError` and vectorized-equilibrium mismatch.
- Green after fix: `.venv/bin/python -m pytest tests/test_kinetics_custom_and_equilibrium.py -v`
- Green after fix: `.venv/bin/python -m pytest tests/ -m "not assimulo"` (`38 passed, 8 deselected`)
- Green after fix: `.venv/bin/python -m pytest --collect-only` (`46 tests collected`)
- Green after fix: `git -c core.whitespace=cr-at-eol diff --check`

Local environment: repository `.venv` with Python 3.11.15. The changed kinetics code is pure NumPy and does not require the assimulo backend.

## Branch Hygiene
- Base branch: `master`
- Source branch: `fix/issue-71-kinetics-custom-equilibrium`
- Branch point: `origin/master` at `1a3ab3155216f07e9a18c60687a7b6b1c5959202`
- `upstream/master` was fetched at `400e1e13ad4ecd3ba202d5fae8c70ec73bdf9c3e` and is already an ancestor of `origin/master`.
- Open PR overlap check found no same-file overlap for `PharmaPy/Kinetics.py` or `tests/test_kinetics_custom_and_equilibrium.py`.
- No prerequisite or stacked PR.
