### PR TITLE
Fix adiabatic evaporator energy residual

### DIFF
--- a/PharmaPy/Evaporators.py
+++ b/PharmaPy/Evaporators.py
@@ -1485,7 +1485,7 @@ class ContinuousEvaporator:
         input_fracs = u_inputs['mole_frac']
         input_temp = u_inputs['temp']
 
-        # Enthalpies
+        # Molar enthalpies [J/mol]
         h_in = self.Inlet.getEnthalpy(temp=input_temp, mole_frac=input_fracs,
                                       basis='mole')
 
@@ -1502,12 +1502,12 @@ class ContinuousEvaporator:
             h_vap = self.Vapor_1.getEnthalpy(temp, mole_frac=y_vap,
                                              basis='mole')
 
-        # Heat transfer
+        # Heat-transfer rate [J/s]
         if self.adiabatic:
             heat_transfer = 0
         else:
-            height_liq = vol_liq / (np.pi/4 * self.diam_tank**2)
-            area_ht = np.pi * self.diam_tank * height_liq + self.area_base
+            height_liq = vol_liq / (np.pi/4 * self.diam_tank**2)  # [m]
+            area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # [m^2]
 
             ht_controls = self.Utility.get_inputs(time)
             temp_ht = ht_controls['temp_in']
@@ -1521,6 +1521,7 @@ class ContinuousEvaporator:
 
             heat_transfer += q_cond
 
+        # Net enthalpy flow [J/s]
         flow_term = input_flow * h_in - flow_liq * h_liq - \
             (1 - self.reflux_ratio) * flow_vap * h_top
         if heat_prof:
@@ -1529,7 +1530,7 @@ class ContinuousEvaporator:
             # Compute balances
             duint_dt = flow_term - heat_transfer
 
-            pv_term = pres * self.vol_tot
+            pv_term = pres * self.vol_tot  # pressure-volume energy [J]
             internal_energy = mol_liq * h_liq + mol_vap * h_vap - pv_term - u_int
 
             out_energy = np.array([duint_dt, internal_energy])

--- a/PharmaPy/Evaporators.py
+++ b/PharmaPy/Evaporators.py
@@ -1480,60 +1480,105 @@ class ContinuousEvaporator:
     def energy_balances(self, time, flow_liq, flow_vap, vol_liq, u_int, temp,
                         x_liq, y_vap, mol_i, mol_liq, mol_vap, pres,
                         u_inputs, heat_prof=False):
+        """Compute the DAE energy residuals.
 
-        input_flow = u_inputs['mole_flow']
-        input_fracs = u_inputs['mole_frac']
-        input_temp = u_inputs['temp']
+        Parameters
+        ----------
+        time : float
+            Current time [s].
+        flow_liq : float
+            Liquid outlet molar flow rate [mol/s].
+        flow_vap : float
+            Vapor outlet molar flow rate [mol/s].
+        vol_liq : float
+            Liquid volume [m**3].
+        u_int : float
+            Internal energy state [J].
+        temp : float
+            Unit temperature [K].
+        x_liq : ndarray
+            Liquid mole fractions [-].
+        y_vap : ndarray
+            Vapor mole fractions [-].
+        mol_i : ndarray
+            Component mole holdups [mol].
+        mol_liq : float
+            Liquid molar holdup [mol].
+        mol_vap : float
+            Vapor molar holdup [mol].
+        pres : float
+            Unit pressure [Pa].
+        u_inputs : dict
+            Inlet controls with ``mole_flow`` [mol/s], ``mole_frac`` [-],
+            and ``temp`` [K].
+        heat_prof : bool, optional
+            Return heat profile terms instead of residuals [-].
+
+        Returns
+        -------
+        ndarray or tuple
+            If ``heat_prof`` is False, residuals for energy rate [J/s] and
+            internal energy [J]. If True, net enthalpy flow [J/s] and
+            heat-transfer rate [J/s].
+        """
+
+        input_flow = u_inputs['mole_flow']  # [mol/s]
+        input_fracs = u_inputs['mole_frac']  # [-]
+        input_temp = u_inputs['temp']  # [K]
 
         # Molar enthalpies [J/mol]
         h_in = self.Inlet.getEnthalpy(temp=input_temp, mole_frac=input_fracs,
-                                      basis='mole')
+                                      basis='mole')  # [J/mol]
 
-        h_liq = self.Liquid_1.getEnthalpy(temp, mole_frac=x_liq, basis='mole')
+        h_liq = self.Liquid_1.getEnthalpy(temp, mole_frac=x_liq,
+                                          basis='mole')  # [J/mol]
 
         if self.reflux_ratio == 0:
             h_top = self.Vapor_1.getEnthalpy(temp, mole_frac=y_vap,
-                                             basis='mole')
-            h_vap = h_top
+                                             basis='mole')  # [J/mol]
+            h_vap = h_top  # [J/mol]
         else:
-            temp_bubble = self.Liquid_1.getBubblePoint(pres, mole_frac=y_vap)
+            temp_bubble = self.Liquid_1.getBubblePoint(
+                pres, mole_frac=y_vap)  # [K]
             h_top = self.Liquid_1.getEnthalpy(temp=temp_bubble,
-                                              mole_frac=y_vap, basis='mole')
+                                              mole_frac=y_vap,
+                                              basis='mole')  # [J/mol]
             h_vap = self.Vapor_1.getEnthalpy(temp, mole_frac=y_vap,
-                                             basis='mole')
+                                             basis='mole')  # [J/mol]
 
         # Heat-transfer rate [J/s]
         if self.adiabatic:
-            heat_transfer = 0
+            heat_transfer = 0  # [J/s]
         else:
             height_liq = vol_liq / (np.pi/4 * self.diam_tank**2)  # [m]
             area_ht = np.pi * self.diam_tank * height_liq + self.area_base  # [m^2]
 
-            ht_controls = self.Utility.get_inputs(time)
-            temp_ht = ht_controls['temp_in']
+            ht_controls = self.Utility.get_inputs(time)  # contains temp_in [K]
+            temp_ht = ht_controls['temp_in']  # [K]
 
-            heat_transfer = self.h_conv * area_ht * (temp - temp_ht)
+            heat_transfer = self.h_conv * area_ht * (temp - temp_ht)  # [J/s]
 
             if self.reflux_ratio == 0:
-                q_cond = 0
+                q_cond = 0  # [J/s]
             else:
-                q_cond = flow_vap * (h_vap - h_top)
+                q_cond = flow_vap * (h_vap - h_top)  # [J/s]
 
             heat_transfer += q_cond
 
         # Net enthalpy flow [J/s]
         flow_term = input_flow * h_in - flow_liq * h_liq - \
-            (1 - self.reflux_ratio) * flow_vap * h_top
+            (1 - self.reflux_ratio) * flow_vap * h_top  # [J/s]
         if heat_prof:
             return flow_term, heat_transfer
         else:
             # Compute balances
-            duint_dt = flow_term - heat_transfer
+            duint_dt = flow_term - heat_transfer  # [J/s]
 
-            pv_term = pres * self.vol_tot  # pressure-volume energy [J]
-            internal_energy = mol_liq * h_liq + mol_vap * h_vap - pv_term - u_int
+            pressure_volume_energy = pres * self.vol_tot  # [J]
+            internal_energy = mol_liq * h_liq + mol_vap * h_vap - \
+                pressure_volume_energy - u_int  # [J]
 
-            out_energy = np.array([duint_dt, internal_energy])
+            out_energy = np.array([duint_dt, internal_energy])  # [J/s, J]
 
             return out_energy
 

--- a/PharmaPy/Evaporators.py
+++ b/PharmaPy/Evaporators.py
@@ -1494,10 +1494,13 @@ class ContinuousEvaporator:
         if self.reflux_ratio == 0:
             h_top = self.Vapor_1.getEnthalpy(temp, mole_frac=y_vap,
                                              basis='mole')
+            h_vap = h_top
         else:
             temp_bubble = self.Liquid_1.getBubblePoint(pres, mole_frac=y_vap)
             h_top = self.Liquid_1.getEnthalpy(temp=temp_bubble,
                                               mole_frac=y_vap, basis='mole')
+            h_vap = self.Vapor_1.getEnthalpy(temp, mole_frac=y_vap,
+                                             basis='mole')
 
         # Heat transfer
         if self.adiabatic:
@@ -1513,11 +1516,7 @@ class ContinuousEvaporator:
 
             if self.reflux_ratio == 0:
                 q_cond = 0
-                h_vap = h_top
             else:
-                h_vap = self.Vapor_1.getEnthalpy(temp, mole_frac=y_vap,
-                                                 basis='mole')
-
                 q_cond = flow_vap * (h_vap - h_top)
 
             heat_transfer += q_cond

--- a/tests/test_evaporator_adiabatic_energy.py
+++ b/tests/test_evaporator_adiabatic_energy.py
@@ -11,21 +11,23 @@ pytestmark = [pytest.mark.assimulo, pytest.mark.unit]
 
 
 class _EnthalpySource:
+    """Provide fixed enthalpy [J/mol] and bubble point [K] test values."""
+
     def __init__(self, enthalpy):
-        self.enthalpy = enthalpy
+        self.enthalpy = enthalpy  # [J/mol]
 
     def getEnthalpy(self, *args, **kwargs):
-        return self.enthalpy
+        return self.enthalpy  # [J/mol]
 
     def getBubblePoint(self, *args, **kwargs):
-        return 325.0
+        return 325.0  # [K]
 
 
 @pytest.mark.parametrize(
     "reflux_ratio, expected_energy_rate",
     [
-        (0, -40.0),
-        (0.25, -10.0),
+        (0, -40.0),  # [-], [J/s]
+        (0.25, -10.0),  # [-], [J/s]
     ],
 )
 def test_adiabatic_energy_residual_includes_vapor_enthalpy(
@@ -33,14 +35,14 @@ def test_adiabatic_energy_residual_includes_vapor_enthalpy(
     # Enthalpies are J/mol; flows are mol/s, amounts are mol, pressure is Pa,
     # and volume is m^3. Thus the two residuals are J/s and J, respectively.
     evaporator = ContinuousEvaporator.__new__(ContinuousEvaporator)
-    evaporator._Inlet = _EnthalpySource(10.0)
-    evaporator.Liquid_1 = _EnthalpySource(20.0)
-    evaporator.Vapor_1 = _EnthalpySource(30.0)
-    evaporator.reflux_ratio = reflux_ratio
-    evaporator.adiabatic = True
-    evaporator.vol_tot = 2.0
+    evaporator._Inlet = _EnthalpySource(10.0)  # [J/mol]
+    evaporator.Liquid_1 = _EnthalpySource(20.0)  # [J/mol]
+    evaporator.Vapor_1 = _EnthalpySource(30.0)  # [J/mol]
+    evaporator.reflux_ratio = reflux_ratio  # [-]
+    evaporator.adiabatic = True  # [-]
+    evaporator.vol_tot = 2.0  # [m^3]
 
-    result = evaporator.energy_balances(
+    result = evaporator.energy_balances(  # [J/s, J]
         time=0.0,
         flow_liq=1.0,
         flow_vap=2.0,
@@ -60,7 +62,8 @@ def test_adiabatic_energy_residual_includes_vapor_enthalpy(
         },
     )
 
-    expected_internal_energy = 3.0 * 20.0 + 4.0 * 30.0 - 5.0 * 2.0 - 40.0
+    expected_internal_energy = 3.0 * 20.0 + 4.0 * 30.0 - \
+        5.0 * 2.0 - 40.0  # [J]
     np.testing.assert_allclose(
         result,
         [expected_energy_rate, expected_internal_energy],

--- a/tests/test_evaporator_adiabatic_energy.py
+++ b/tests/test_evaporator_adiabatic_energy.py
@@ -17,15 +17,26 @@ class _EnthalpySource:
     def getEnthalpy(self, *args, **kwargs):
         return self.enthalpy
 
+    def getBubblePoint(self, *args, **kwargs):
+        return 325.0
 
-def test_adiabatic_energy_residual_includes_vapor_enthalpy():
+
+@pytest.mark.parametrize(
+    "reflux_ratio, expected_energy_rate",
+    [
+        (0, -40.0),
+        (0.25, -10.0),
+    ],
+)
+def test_adiabatic_energy_residual_includes_vapor_enthalpy(
+        reflux_ratio, expected_energy_rate):
     # Enthalpies are J/mol; flows are mol/s, amounts are mol, pressure is Pa,
     # and volume is m^3. Thus the two residuals are J/s and J, respectively.
     evaporator = ContinuousEvaporator.__new__(ContinuousEvaporator)
     evaporator._Inlet = _EnthalpySource(10.0)
     evaporator.Liquid_1 = _EnthalpySource(20.0)
     evaporator.Vapor_1 = _EnthalpySource(30.0)
-    evaporator.reflux_ratio = 0
+    evaporator.reflux_ratio = reflux_ratio
     evaporator.adiabatic = True
     evaporator.vol_tot = 2.0
 
@@ -49,7 +60,6 @@ def test_adiabatic_energy_residual_includes_vapor_enthalpy():
         },
     )
 
-    expected_energy_rate = 4.0 * 10.0 - 1.0 * 20.0 - 2.0 * 30.0
     expected_internal_energy = 3.0 * 20.0 + 4.0 * 30.0 - 5.0 * 2.0 - 40.0
     np.testing.assert_allclose(
         result,

--- a/tests/test_evaporator_adiabatic_energy.py
+++ b/tests/test_evaporator_adiabatic_energy.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+
+pytest.importorskip("assimulo")
+
+from PharmaPy.Evaporators import ContinuousEvaporator
+
+
+pytestmark = [pytest.mark.assimulo, pytest.mark.unit]
+
+
+class _EnthalpySource:
+    def __init__(self, enthalpy):
+        self.enthalpy = enthalpy
+
+    def getEnthalpy(self, *args, **kwargs):
+        return self.enthalpy
+
+
+def test_adiabatic_energy_residual_includes_vapor_enthalpy():
+    evaporator = ContinuousEvaporator.__new__(ContinuousEvaporator)
+    evaporator._Inlet = _EnthalpySource(10.0)
+    evaporator.Liquid_1 = _EnthalpySource(20.0)
+    evaporator.Vapor_1 = _EnthalpySource(30.0)
+    evaporator.reflux_ratio = 0
+    evaporator.adiabatic = True
+    evaporator.vol_tot = 2.0
+
+    result = evaporator.energy_balances(
+        time=0.0,
+        flow_liq=1.0,
+        flow_vap=2.0,
+        vol_liq=1.0,
+        u_int=40.0,
+        temp=350.0,
+        x_liq=np.array([1.0]),
+        y_vap=np.array([1.0]),
+        mol_i=np.array([3.0]),
+        mol_liq=3.0,
+        mol_vap=4.0,
+        pres=5.0,
+        u_inputs={
+            "mole_flow": 4.0,
+            "mole_frac": np.array([1.0]),
+            "temp": 300.0,
+        },
+    )
+
+    np.testing.assert_allclose(result, [-40.0, 130.0])

--- a/tests/test_evaporator_adiabatic_energy.py
+++ b/tests/test_evaporator_adiabatic_energy.py
@@ -19,6 +19,8 @@ class _EnthalpySource:
 
 
 def test_adiabatic_energy_residual_includes_vapor_enthalpy():
+    # Enthalpies are J/mol; flows are mol/s, amounts are mol, pressure is Pa,
+    # and volume is m^3. Thus the two residuals are J/s and J, respectively.
     evaporator = ContinuousEvaporator.__new__(ContinuousEvaporator)
     evaporator._Inlet = _EnthalpySource(10.0)
     evaporator.Liquid_1 = _EnthalpySource(20.0)
@@ -47,4 +49,9 @@ def test_adiabatic_energy_residual_includes_vapor_enthalpy():
         },
     )
 
-    np.testing.assert_allclose(result, [-40.0, 130.0])
+    expected_energy_rate = 4.0 * 10.0 - 1.0 * 20.0 - 2.0 * 30.0
+    expected_internal_energy = 3.0 * 20.0 + 4.0 * 30.0 - 5.0 * 2.0 - 40.0
+    np.testing.assert_allclose(
+        result,
+        [expected_energy_rate, expected_internal_energy],
+    )


### PR DESCRIPTION
## Summary

- initialize vapor enthalpy before the adiabatic/non-adiabatic heat-transfer split
- preserve the existing reflux and condenser enthalpy behavior
- add focused regression coverage for both zero and nonzero reflux adiabatic energy residual paths
- document the `ContinuousEvaporator.energy_balances` unit contract with Numpy-format parameter and return documentation

## Unit Contract

- Inlet, liquid outlet, and vapor outlet flows use molar flow rates [mol/s].
- Liquid and vapor compositions are mole fractions [-].
- Enthalpies from phase objects are molar enthalpies [J/mol].
- Heat-transfer and net enthalpy-flow terms are energy rates [J/s].
- The pressure-volume contribution is stored as `pressure_volume_energy` [J].
- The returned residual vector contains energy rate [J/s] followed by internal energy [J].

## Validation

- `conda run -n pharmapy python -m pytest tests/test_evaporator_adiabatic_energy.py -q` (2 passed, 2 warnings)
- `conda run -n pharmapy python -m pytest tests/ -q` (43 passed, 32 warnings)
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check -- PharmaPy/Evaporators.py tests/test_evaporator_adiabatic_energy.py`
- Earlier regression mutation checks confirmed the test fails before the `h_vap` fix for both covered adiabatic paths.

## Branch Hygiene

- Base: `master`
- Source branch point: current `origin/master`
- Stacked: no
- Prerequisites: none
- No changed-file overlap with currently open PRs

Closes #69
