### PR TITLE
Fix BatchCryst concentration Jacobian sign

### DIFF
--- a/PharmaPy/Crystallizers.py
+++ b/PharmaPy/Crystallizers.py
@@ -1402,7 +1402,7 @@ class BatchCryst(_BaseCryst):
             dtr_dconc_tg = g_exp * tr / conc_diff
 
             first_conc = np.outer(self.kron_jtg - w_conc/rho_l, self.kron_jtg)
-            second_conc = tr/rho_l * np.eye(len(w_conc))
+            second_conc = -tr/rho_l * np.eye(len(w_conc))
 
             dfconc_dconc = -1/vol_liq * \
                 (dtr_dconc_tg * first_conc + second_conc)

--- a/tests/test_batch_cryst_concentration_jacobian.py
+++ b/tests/test_batch_cryst_concentration_jacobian.py
@@ -92,26 +92,12 @@ def test_batch_cryst_concentration_jacobian_diagonal_matches_material_balance(mo
         return_only=False,
     )
 
-    rho_l = crystallizer.Liquid_1.getDensity(temp=298.15)
-    rho_c = crystallizer.Solid_1.getDensity(temp=298.15)
-    tr = (
-        3
-        * crystallizer.Solid_1.kv
-        * crystallizer.Kinetics.growth
-        * moments[2]
-        * rho_c
-        * (1e-6) ** 3
-    )
-    dtr_dconc_tg = crystallizer.Kinetics.params["growth"][-1] * tr / (
-        mass_conc[crystallizer.target_ind] - crystallizer.Kinetics.get_solubility(298.15, mass_conc)
-    )
-    first_conc = np.outer(
-        crystallizer.kron_jtg - mass_conc / rho_l,
-        crystallizer.kron_jtg,
-    )
-    expected_conc_block = -1 / vol_liq * (
-        dtr_dconc_tg * first_conc - tr / rho_l * np.eye(len(mass_conc))
-    )
+    # Hand-computed from the fixture values: tr = 0.072,
+    # dtr_dconc_tg = 0.24, and tr / rho_l = 7.2e-5.
+    expected_conc_block = np.array([
+        [-0.119898, 0.0],
+        [2.4e-5, 3.6e-5],
+    ])
 
     np.testing.assert_allclose(
         jacobian[crystallizer.num_distr:-1, crystallizer.num_distr:-1],

--- a/tests/test_batch_cryst_concentration_jacobian.py
+++ b/tests/test_batch_cryst_concentration_jacobian.py
@@ -1,0 +1,121 @@
+import sys
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def _stub_assimulo_modules(monkeypatch):
+    assimulo = ModuleType("assimulo")
+
+    solvers = ModuleType("assimulo.solvers")
+    solvers.CVode = object
+
+    problem = ModuleType("assimulo.problem")
+    problem.Explicit_Problem = object
+
+    monkeypatch.setitem(sys.modules, "assimulo", assimulo)
+    monkeypatch.setitem(sys.modules, "assimulo.solvers", solvers)
+    monkeypatch.setitem(sys.modules, "assimulo.problem", problem)
+
+
+def _import_batch_cryst(monkeypatch):
+    try:
+        from PharmaPy.Crystallizers import BatchCryst
+    except ModuleNotFoundError as exc:
+        if exc.name != "assimulo":
+            raise
+        _stub_assimulo_modules(monkeypatch)
+
+        from PharmaPy.Crystallizers import BatchCryst
+
+    return BatchCryst
+
+
+class _Liquid:
+    def getDensity(self, temp=None):
+        return 1000.0
+
+
+class _Solid:
+    kv = 2.0
+
+    def getDensity(self, temp=None):
+        return 1500.0
+
+
+class _Kinetics:
+    prim_nucl = 0.0
+    sec_nucl = 0.0
+    growth = 2.0e12
+    params = {
+        "growth": [0.0, 0.0, 1.0],
+        "nucl_prim": [0.0, 0.0, 1.0],
+        "nucl_sec": [0.0, 0.0, 0.0, 0.0],
+    }
+
+    def get_solubility(self, temp, conc):
+        return 0.25
+
+
+def test_batch_cryst_concentration_jacobian_diagonal_matches_material_balance(monkeypatch):
+    BatchCryst = _import_batch_cryst(monkeypatch)
+
+    crystallizer = BatchCryst.__new__(BatchCryst)
+    crystallizer.num_distr = 4
+    crystallizer.num_species = 2
+    crystallizer.target_ind = 0
+    crystallizer.kron_jtg = np.array([1.0, 0.0])
+    crystallizer.controls = {
+        "temp": {
+            "fun": lambda time: 298.15,
+            "args": (),
+            "kwargs": {},
+        }
+    }
+    crystallizer.Liquid_1 = _Liquid()
+    crystallizer.Solid_1 = _Solid()
+    crystallizer._Kinetics = _Kinetics()
+
+    moments = np.array([1.0, 2.0, 4.0, 8.0])
+    mass_conc = np.array([0.55, 0.20])
+    vol_liq = 2.0
+    states = np.concatenate((moments, mass_conc, [vol_liq]))
+
+    jacobian = crystallizer.jac_states(
+        time=0.0,
+        states=states,
+        params=None,
+        return_only=False,
+    )
+
+    rho_l = crystallizer.Liquid_1.getDensity(temp=298.15)
+    rho_c = crystallizer.Solid_1.getDensity(temp=298.15)
+    tr = (
+        3
+        * crystallizer.Solid_1.kv
+        * crystallizer.Kinetics.growth
+        * moments[2]
+        * rho_c
+        * (1e-6) ** 3
+    )
+    dtr_dconc_tg = crystallizer.Kinetics.params["growth"][-1] * tr / (
+        mass_conc[crystallizer.target_ind] - crystallizer.Kinetics.get_solubility(298.15, mass_conc)
+    )
+    first_conc = np.outer(
+        crystallizer.kron_jtg - mass_conc / rho_l,
+        crystallizer.kron_jtg,
+    )
+    expected_conc_block = -1 / vol_liq * (
+        dtr_dconc_tg * first_conc - tr / rho_l * np.eye(len(mass_conc))
+    )
+
+    np.testing.assert_allclose(
+        jacobian[crystallizer.num_distr:-1, crystallizer.num_distr:-1],
+        expected_conc_block,
+        rtol=1e-12,
+        atol=1e-12,
+    )


### PR DESCRIPTION
## Summary

Closes #26.

- Correct the `BatchCryst.jac_states` concentration Jacobian self-derivative sign so it matches the differentiated material balance.
- Add the regression test from the maintainer-gated triage comment to pin the concentration Jacobian block.

## Triage And Acceptance Criteria

Triage comment: https://github.com/SECQUOIA/PharmaPy/issues/26#issuecomment-4959072820

This PR satisfies the recorded criteria:
- `BatchCryst.jac_states(..., return_only=False)` uses the differentiated material-balance sign for the concentration self-derivative term.
- The regression test fails on base commit `1a3ab3155216f07e9a18c60687a7b6b1c5959202` and passes with this fix.
- Existing non-Assimulo pytest tests continue to pass.

## Local Checks

- Reproduced red first: `/home/yirangpark/repos/secquoia/PharmaPy/.venv/bin/python -m pytest tests/test_batch_cryst_concentration_jacobian.py -q`
- Targeted green: `/home/yirangpark/repos/secquoia/PharmaPy/.venv/bin/python -m pytest tests/test_batch_cryst_concentration_jacobian.py -q`
- Broader green: `/home/yirangpark/repos/secquoia/PharmaPy/.venv/bin/python -m pytest tests/ -m "not assimulo" -q`
- Whitespace: `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check`

## Branch Hygiene

- Base branch: `master`
- Source branch point: `origin/master` at `1a3ab3155216f07e9a18c60687a7b6b1c5959202`
- Upstream status: `upstream/master` is contained in `origin/master`
- Open PR overlap: PR #106 also touches `PharmaPy/Crystallizers.py`, but its current hunks are in crystallizer energy/jacket paths around lines 590, 1874, and 2216. This PR touches the `BatchCryst.jac_states` concentration block around line 1402, so the current overlap is same-file but not same-hunk. If PR #106 lands first, rebase this branch on the updated `master` before merging.
