### PR TITLE
Test drying energy rate basis

### DIFF
--- a/tests/test_drying_energy_rate_basis.py
+++ b/tests/test_drying_energy_rate_basis.py
@@ -5,7 +5,10 @@ instead of building a complete ``solve_unit`` drying example. That keeps the
 test to a single right-hand-side evaluation while still exercising the real
 ``unit_model -> energy_balance`` path for issue #48. No checked-in PharmaPy
 example currently constructs an end-to-end Drying run from full phase/cake
-classes, so the fixture below documents the assumed state layout and units.
+classes. External class-material examples can seed future integration coverage,
+but a full Drying transient regression is deferred until the open Drying
+correctness issues are resolved; this fixture documents the assumed state layout
+and units for the focused energy-basis path.
 """
 
 from types import SimpleNamespace

--- a/tests/test_drying_energy_rate_basis.py
+++ b/tests/test_drying_energy_rate_basis.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.assimulo
 
 def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     """Energy terms combine mass drying rates with mass-basis heat data."""
-    dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer = Drying(number_nodes=3, supercrit_names=["nitrogen"])
     dryer.num_volatiles = 2
     dryer.idx_volatiles = np.array([0, 2])
     dryer.idx_supercrit = np.array([1])
@@ -21,8 +21,8 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     dryer.cp_sol = 1000.0  # [J/kg/K]
     dryer.s_inf = 0.1
     dryer.dPg_dz = 2.0
-    dryer.dz = np.ones(2)
-    dryer.pres_gas = np.array([60000.0, 122000.0])  # gives rho_gas [2, 4]
+    dryer.dz = np.ones(3)
+    dryer.pres_gas = np.array([60000.0, 122000.0, 62000.0])
     dryer.CakePhase = SimpleNamespace(alpha=1.2)
     dryer.h_T_j = 0.0
     dryer.a_V = 1.0
@@ -34,12 +34,14 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
         num_species=3,
         mw=np.array([18.0, 28.0, 46.0]),  # [g/mol]
         rho_liq=np.array([800.0, 850.0, 800.0]),  # [kg/m**3]
-        getCp=lambda temp, mass_frac, basis: np.array([2000.0, 2000.0]),
+        getCp=lambda temp, mass_frac, basis: np.array([2000.0, 2000.0, 2000.0]),
     )
     dryer.Vapor_1 = SimpleNamespace(
         mw=np.array([83.14, 83.14, 83.14]),  # [g/mol]
-        getViscosity=lambda temp, mass_frac: np.ones(2),
-        getCp=lambda temp, mass_frac, basis: np.array([1000.0, 1200.0]),
+        getViscosity=lambda temp, mass_frac: np.ones(3),
+        getCp=lambda temp, mass_frac, basis: np.array([1000.0, 1200.0, 1500.0]),
+        # One latent heat value per volatile component; the node count is
+        # intentionally different so this cannot be read as per-node data.
         getHeatVaporization=lambda temp, basis: np.array([2.0e6, 1.0e6]),
     )
     dryer.get_inputs = lambda time: {
@@ -52,6 +54,7 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     molar_dry_rate = np.array([
         [2.0, 0.0, 4.0],
         [3.0, 0.0, 5.0],
+        [1.0, 0.0, 2.0],
     ])  # [mol/m**3/s]
     monkeypatch.setattr(
         dryer,
@@ -67,28 +70,34 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
         dryer,
         "material_balance",
         lambda *args, **kwargs: [
-            np.zeros(2),
-            np.zeros((2, 3)),
-            np.zeros((2, 2)),
+            np.zeros(3),
+            np.zeros((3, 3)),
+            np.zeros((3, 2)),
         ],
     )
 
     states = np.array([
         [0.5, 0.10, 0.80, 0.10, 0.0, 1.0, 300.0, 299.0],
         [0.5, 0.20, 0.70, 0.10, 0.0, 1.0, 305.0, 304.0],
+        [0.5, 0.30, 0.60, 0.10, 0.0, 1.0, 310.0, 309.0],
     ])
 
     derivatives = dryer.unit_model(time=0.0, states=states.ravel())
-    derivatives = derivatives.reshape(2, -1)
+    derivatives = derivatives.reshape(3, -1)
 
     # Sensible power is cp_gas * (T_gas - 295 K) * sum(m_dot_i).
-    expected_gas_temperature_rate = np.array([1100.0 / 450.0, 3408.0 / 1100.0])
+    expected_gas_temperature_rate = np.array([
+        1100.0 / 450.0,
+        3408.0 / 1100.0,
+        2475.0 / 700.0,
+    ])
 
-    # The mass-rate latent powers are [256000, 338000] J/m**3/s. Issue #24
+    # The mass-rate latent powers are [256000, 338000, 128000] J/m**3/s. Issue #24
     # separately tracks the existing factor of two applied to those powers.
     expected_condensed_temperature_rate = np.array([
         -512000.0 / 900000.0,
         -676000.0 / 900000.0,
+        -256000.0 / 900000.0,
     ])
 
     np.testing.assert_allclose(

--- a/tests/test_drying_energy_rate_basis.py
+++ b/tests/test_drying_energy_rate_basis.py
@@ -1,3 +1,13 @@
+"""Drying energy-basis regression coverage.
+
+This file uses a compact synthetic Drying fixture and calls ``unit_model`` once
+instead of building a complete ``solve_unit`` drying example. That keeps the
+test to a single right-hand-side evaluation while still exercising the real
+``unit_model -> energy_balance`` path for issue #48. No checked-in PharmaPy
+example currently constructs an end-to-end Drying run from full phase/cake
+classes, so the fixture below documents the assumed state layout and units.
+"""
+
 from types import SimpleNamespace
 
 import numpy as np
@@ -13,41 +23,49 @@ pytestmark = pytest.mark.assimulo
 def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     """Energy terms combine mass drying rates with mass-basis heat data."""
     dryer = Drying(number_nodes=3, supercrit_names=["nitrogen"])
-    dryer.num_volatiles = 2
-    dryer.idx_volatiles = np.array([0, 2])
-    dryer.idx_supercrit = np.array([1])
-    dryer.porosity = 0.5
+    dryer.num_volatiles = 2  # [-]
+    dryer.idx_volatiles = np.array([0, 2])  # component indices [-]
+    dryer.idx_supercrit = np.array([1])  # component indices [-]
+    dryer.porosity = 0.5  # [-]
     dryer.rho_sol = 1000.0  # [kg/m**3]
     dryer.cp_sol = 1000.0  # [J/kg/K]
-    dryer.s_inf = 0.1
-    dryer.dPg_dz = 2.0
-    dryer.dz = np.ones(3)
-    dryer.pres_gas = np.array([60000.0, 122000.0, 62000.0])
-    dryer.CakePhase = SimpleNamespace(alpha=1.2)
-    dryer.h_T_j = 0.0
-    dryer.a_V = 1.0
-    dryer.h_T_loss = 0.0
-    dryer.cake_height = 1.0
-    dryer.T_ambient = 298.15
+    dryer.s_inf = 0.1  # [-]
+    dryer.dPg_dz = 2.0  # [Pa/m]
+    dryer.dz = np.ones(3)  # [m]
+    dryer.pres_gas = np.array([60000.0, 122000.0, 62000.0])  # [Pa]
+    dryer.CakePhase = SimpleNamespace(alpha=1.2)  # [m/kg]
+    dryer.h_T_j = 0.0  # [W/m**2/K]
+    dryer.a_V = 1.0  # [m**2/m**3]
+    dryer.h_T_loss = 0.0  # [W/m**2/K]
+    dryer.cake_height = 1.0  # [m]
+    dryer.T_ambient = 298.15  # [K]
 
     dryer.Liquid_1 = SimpleNamespace(
-        num_species=3,
+        num_species=3,  # [-]
         mw=np.array([18.0, 28.0, 46.0]),  # [g/mol]
         rho_liq=np.array([800.0, 850.0, 800.0]),  # [kg/m**3]
-        getCp=lambda temp, mass_frac, basis: np.array([2000.0, 2000.0, 2000.0]),
+        getCp=lambda temp, mass_frac, basis: np.array([
+            2000.0,
+            2000.0,
+            2000.0,
+        ]),  # [J/kg/K]
     )
     dryer.Vapor_1 = SimpleNamespace(
         mw=np.array([83.14, 83.14, 83.14]),  # [g/mol]
-        getViscosity=lambda temp, mass_frac: np.ones(3),
-        getCp=lambda temp, mass_frac, basis: np.array([1000.0, 1200.0, 1500.0]),
+        getViscosity=lambda temp, mass_frac: np.ones(3),  # [Pa*s]
+        getCp=lambda temp, mass_frac, basis: np.array([
+            1000.0,
+            1200.0,
+            1500.0,
+        ]),  # [J/kg/K]
         # One latent heat value per volatile component; the node count is
         # intentionally different so this cannot be read as per-node data.
-        getHeatVaporization=lambda temp, basis: np.array([2.0e6, 1.0e6]),
+        getHeatVaporization=lambda temp, basis: np.array([2.0e6, 1.0e6]),  # [J/kg]
     )
     dryer.get_inputs = lambda time: {
         "Inlet": {
-            "mass_frac": np.array([0.05, 0.90, 0.05]),
-            "temp": 300.0,
+            "mass_frac": np.array([0.05, 0.90, 0.05]),  # [-]
+            "temp": 300.0,  # [K]
         }
     }
 
@@ -64,33 +82,36 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     monkeypatch.setattr(
         drying_module,
         "high_resolution_fvm",
-        lambda values, boundary_cond: np.zeros(values.size + 1),
+        lambda values, boundary_cond: np.zeros(values.size + 1),  # [K]
     )
     monkeypatch.setattr(
         dryer,
         "material_balance",
         lambda *args, **kwargs: [
-            np.zeros(3),
-            np.zeros((3, 3)),
-            np.zeros((3, 2)),
+            np.zeros(3),  # saturation derivative [1/s]
+            np.zeros((3, 3)),  # gas mass-fraction derivative [1/s]
+            np.zeros((3, 2)),  # liquid mass-fraction derivative [1/s]
         ],
     )
 
+    # Columns: saturation [-], y_gas [-], x_liq [-], T_gas [K], T_cond [K].
     states = np.array([
         [0.5, 0.10, 0.80, 0.10, 0.0, 1.0, 300.0, 299.0],
         [0.5, 0.20, 0.70, 0.10, 0.0, 1.0, 305.0, 304.0],
         [0.5, 0.30, 0.60, 0.10, 0.0, 1.0, 310.0, 309.0],
     ])
 
+    # State derivatives follow the same layout as states, with time basis [1/s].
     derivatives = dryer.unit_model(time=0.0, states=states.ravel())
     derivatives = derivatives.reshape(3, -1)
 
-    # Sensible power is cp_gas * (T_gas - 295 K) * sum(m_dot_i).
+    # Sensible power [J/m**3/s] divided by gas capacity [J/m**3/K].
+    # power = cp_gas [J/kg/K] * (T_gas - 295 K) * sum(m_dot_i) [kg/m**3/s].
     expected_gas_temperature_rate = np.array([
         1100.0 / 450.0,
         3408.0 / 1100.0,
         2475.0 / 700.0,
-    ])
+    ])  # [K/s]
 
     # The mass-rate latent powers are [256000, 338000, 128000] J/m**3/s. Issue #24
     # separately tracks the existing factor of two applied to those powers.
@@ -98,7 +119,7 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
         -512000.0 / 900000.0,
         -676000.0 / 900000.0,
         -256000.0 / 900000.0,
-    ])
+    ])  # [K/s]
 
     np.testing.assert_allclose(
         derivatives[:, -2], expected_gas_temperature_rate

--- a/tests/test_drying_energy_rate_basis.py
+++ b/tests/test_drying_energy_rate_basis.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("assimulo")
+import PharmaPy.Drying_Model as drying_module
+from PharmaPy.Drying_Model import Drying
+
+pytestmark = pytest.mark.assimulo
+
+
+def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
+    """Energy terms combine mass drying rates with mass-basis heat data."""
+    dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer.num_volatiles = 2
+    dryer.idx_volatiles = np.array([0, 2])
+    dryer.idx_supercrit = np.array([1])
+    dryer.porosity = 0.5
+    dryer.rho_sol = 1000.0  # [kg/m**3]
+    dryer.cp_sol = 1000.0  # [J/kg/K]
+    dryer.s_inf = 0.1
+    dryer.dPg_dz = 2.0
+    dryer.dz = np.ones(2)
+    dryer.pres_gas = np.array([60000.0, 122000.0])  # gives rho_gas [2, 4]
+    dryer.CakePhase = SimpleNamespace(alpha=1.2)
+    dryer.h_T_j = 0.0
+    dryer.a_V = 1.0
+    dryer.h_T_loss = 0.0
+    dryer.cake_height = 1.0
+    dryer.T_ambient = 298.15
+
+    dryer.Liquid_1 = SimpleNamespace(
+        num_species=3,
+        mw=np.array([18.0, 28.0, 46.0]),  # [g/mol]
+        rho_liq=np.array([800.0, 850.0, 800.0]),  # [kg/m**3]
+        getCp=lambda temp, mass_frac, basis: np.array([2000.0, 2000.0]),
+    )
+    dryer.Vapor_1 = SimpleNamespace(
+        mw=np.array([83.14, 83.14, 83.14]),  # [g/mol]
+        getViscosity=lambda temp, mass_frac: np.ones(2),
+        getCp=lambda temp, mass_frac, basis: np.array([1000.0, 1200.0]),
+        getHeatVaporization=lambda temp, basis: np.array([2.0e6, 1.0e6]),
+    )
+    dryer.get_inputs = lambda time: {
+        "Inlet": {
+            "mass_frac": np.array([0.05, 0.90, 0.05]),
+            "temp": 300.0,
+        }
+    }
+
+    molar_dry_rate = np.array([
+        [2.0, 0.0, 4.0],
+        [3.0, 0.0, 5.0],
+    ])  # [mol/m**3/s]
+    monkeypatch.setattr(
+        dryer,
+        "get_drying_rate",
+        lambda x_liq, temp_sol, y_gas, pres_gas: molar_dry_rate,
+    )
+    monkeypatch.setattr(
+        drying_module,
+        "high_resolution_fvm",
+        lambda values, boundary_cond: np.zeros(values.size + 1),
+    )
+    monkeypatch.setattr(
+        dryer,
+        "material_balance",
+        lambda *args, **kwargs: [
+            np.zeros(2),
+            np.zeros((2, 3)),
+            np.zeros((2, 2)),
+        ],
+    )
+
+    states = np.array([
+        [0.5, 0.10, 0.80, 0.10, 0.0, 1.0, 300.0, 299.0],
+        [0.5, 0.20, 0.70, 0.10, 0.0, 1.0, 305.0, 304.0],
+    ])
+
+    derivatives = dryer.unit_model(time=0.0, states=states.ravel())
+    derivatives = derivatives.reshape(2, -1)
+
+    # Sensible power is cp_gas * (T_gas - 295 K) * sum(m_dot_i).
+    expected_gas_temperature_rate = np.array([1100.0 / 450.0, 3408.0 / 1100.0])
+
+    # The mass-rate latent powers are [256000, 338000] J/m**3/s. Issue #24
+    # separately tracks the existing factor of two applied to those powers.
+    expected_condensed_temperature_rate = np.array([
+        -512000.0 / 900000.0,
+        -676000.0 / 900000.0,
+    ])
+
+    np.testing.assert_allclose(
+        derivatives[:, -2], expected_gas_temperature_rate
+    )
+    np.testing.assert_allclose(
+        derivatives[:, -1], expected_condensed_temperature_rate
+    )


### PR DESCRIPTION
## Summary

- Add a focused Drying `unit_model` regression that drives the real energy-balance call path.
- Verify molar drying rates are converted component-wise to mass rates before the gas sensible-heat and condensed latent-heat terms consume them.
- Pin independently derived gas and condensed temperature-rate results while leaving issue #24's separate latent-heat multiplier unchanged.

Refs #21, #24, #48, #108.

## Acceptance Criteria

- [x] Gas sensible heat combines `cpg` in J/kg/K with total drying rate in kg/m^3/s.
- [x] Condensed latent cooling combines latent heat in J/kg with component drying rates in kg/m^3/s.
- [x] The regression fails against unchanged `origin/master` and passes with PR #108's shared conversion.
- [x] The unrelated factor-of-two correction remains scoped to #24.

## Dimensional Analysis

- `get_drying_rate`: mol/m^3/s.
- PR #108 conversion: `(mol/m^3/s) * (kg/mol) = kg/m^3/s`.
- Sensible term: `(J/kg/K) * K * (kg/m^3/s) = J/m^3/s`.
- Latent term: `(kg/m^3/s) * (J/kg) = J/m^3/s`.

## Coordination Notes

- This PR is stacked on PR #108 because that PR owns the single shared molar-to-mass conversion in `unit_model`. Duplicating the conversion in `energy_balance` would double-convert after #108 lands.
- Closure ownership: PR #108 supplies the production fix, while this PR supplies the energy-specific regression. Keep #48 open until both changes reach `master`, then close it manually with links to #108 and this PR.
- Issue #24 owns removal of the existing `* 2` latent-heat factor on the same energy expression. This PR documents and tests the current multiplier without changing its behavior; #24 will need to update the pinned condensed-rate expectation when it removes the multiplier.
- A full class-material/Purdue-style `solve_unit` Drying transient example is intentionally deferred. The blocker is not the absence of a checked-in example; it is that open Drying correctness work still affects realistic transient assertions (#21 / PR #108, #24, #28, #37, #42, #81, and #101). Once those land, the class examples can seed broader integration coverage, likely under testing umbrella #7 or a dedicated follow-up issue.
- No other open PR adds or changes `tests/test_drying_energy_rate_basis.py`. PR #108 overlaps in `PharmaPy/Drying_Model.py` and `tests/test_drying_model.py`, but those changes are the prerequisite base rather than competing hunks.

## Tests

- `conda run -n pharmapy python -m pytest tests/test_drying_model.py tests/test_drying_energy_rate_basis.py -q` — 5 passed.
- `conda run -n pharmapy python -m pytest tests/ -m "not assimulo"` — 33 passed, 12 deselected.
- `conda run -n pharmapy python -m pytest tests/ -m assimulo` — 12 passed, 33 deselected.
- Red check on exact `origin/master` (`1a3ab31`) — failed as expected: gas energy rates were about 27 times the mass-basis expectations.

## Branch Hygiene

- Base branch: `fix/issue-21-drying-gas-mass-rate` (non-default).
- Source branch point: `beb53e40d07bb06a7be0e573858e52947f808cbb`, the current head of PR #108.
- Stacked status: stacked directly on PR #108.
- Prerequisite: PR #108 must merge before this PR is retargeted to `master` or merged through the stack.
- This test-only PR intentionally uses `Refs #48`; close #48 manually after PR #108 and this PR both reach `master`.
