### PR TITLE
Fix ContinuousExtractor mode routing

### DIFF
--- a/PharmaPy/Extractors.py
+++ b/PharmaPy/Extractors.py
@@ -17,6 +17,7 @@ from PharmaPy.Results import DynamicResult
 
 
 def material_setter(instance, oper_mode):
+    """Return inlet metadata for batch amounts or continuous mole flow."""
     name_comp = instance.name_species
     num_comp = len(name_comp)
     states_di = {
@@ -25,7 +26,7 @@ def material_setter(instance, oper_mode):
         'moles_heavy': {'dim': 1, 'type': 'alg'},
         'moles_light': {'dim': 1, 'type': 'alg'}}
 
-    if oper_mode == 'continuous':
+    if oper_mode == 'Continuous':
         in_flow = instance.mole_flow
     else:
         in_flow = instance.moles
@@ -45,7 +46,7 @@ class ContinuousExtractor:
 
         self.gamma_method = gamma_method
 
-        self.oper_mode = 'Batch'
+        self.oper_mode = 'Continuous'
 
     @property
     def Inlet(self):
@@ -242,7 +243,7 @@ class ContinuousExtractor:
         path = self.matter.path_data
 
         # Store in objects
-        if self.oper_mode == 'continuous':
+        if self.oper_mode == 'Continuous':
             Liquid_a = LiquidStream(path, mole_frac=xa_liq,
                                     mole_flow=liquid_a,
                                     temp=self.temp, pres=self.pres)
@@ -289,6 +290,7 @@ class BatchExtractor(ContinuousExtractor):
     def __init__(self, k_fun=None, gamma_method='UNIQUAC'):
         super().__init__(k_fun, gamma_method)
 
+        self.oper_mode = 'Batch'
         self._Phases = None
 
     @property

--- a/PharmaPy/Extractors.py
+++ b/PharmaPy/Extractors.py
@@ -17,7 +17,24 @@ from PharmaPy.Results import DynamicResult
 
 
 def material_setter(instance, oper_mode):
-    """Return inlet metadata for batch amounts or continuous mole flow."""
+    """Return inlet metadata for extractor amount or flow routing.
+
+    Parameters
+    ----------
+    instance : LiquidPhase or LiquidStream
+        Material object passed to the extractor. Batch phases provide total
+        ``moles`` [mol]; continuous streams provide ``mole_flow`` [mol/s].
+    oper_mode : {'Batch', 'Continuous'}
+        Extractor operating mode. ``Continuous`` selects flow-rate semantics;
+        ``Batch`` selects amount semantics.
+
+    Returns
+    -------
+    out : dict
+        Inlet metadata with ``in_flow`` in mol/s for continuous operation or
+        mol for batch operation, ``temp`` [K], ``pres`` [Pa], component count,
+        and result-state metadata.
+    """
     name_comp = instance.name_species
     num_comp = len(name_comp)
     states_di = {
@@ -290,6 +307,8 @@ class BatchExtractor(ContinuousExtractor):
     def __init__(self, k_fun=None, gamma_method='UNIQUAC'):
         super().__init__(k_fun, gamma_method)
 
+        # ``super`` sets the continuous default; batch extraction must keep
+        # amount semantics [mol] for Phases and downstream result objects.
         self.oper_mode = 'Batch'
         self._Phases = None
 

--- a/tests/test_extractor_modes.py
+++ b/tests/test_extractor_modes.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pytest
+
+from PharmaPy.Extractors import BatchExtractor, ContinuousExtractor
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Inlet:
+    name_species = ["solute", "solvent"]
+    mole_flow = 8.0
+    moles = 3.0
+    temp = 298.15
+    pres = 101325.0
+    mole_frac = np.array([0.25, 0.75])
+    path_data = "dummy-path"
+
+
+class _DummyOutlet:
+    def __init__(self, path, mole_frac, temp, pres, **amount):
+        self.path = path
+        self.mole_frac = mole_frac
+        self.temp = temp
+        self.pres = pres
+        self.amount = amount
+
+    def getDensity(self, basis):
+        assert basis == "mole"
+        return 1000.0
+
+
+class _DummyStream(_DummyOutlet):
+    pass
+
+
+class _DummyPhase(_DummyOutlet):
+    pass
+
+
+def test_continuous_extractor_uses_mole_flow_and_stream_outlets(monkeypatch):
+    created = {"stream": [], "phase": []}
+
+    def stream_factory(*args, **kwargs):
+        outlet = _DummyStream(*args, **kwargs)
+        created["stream"].append(outlet)
+        return outlet
+
+    def phase_factory(*args, **kwargs):
+        outlet = _DummyPhase(*args, **kwargs)
+        created["phase"].append(outlet)
+        return outlet
+
+    monkeypatch.setattr("PharmaPy.Extractors.LiquidStream", stream_factory)
+    monkeypatch.setattr("PharmaPy.Extractors.LiquidPhase", phase_factory)
+
+    extractor = ContinuousExtractor()
+    extractor.Inlet = _Inlet()
+
+    assert extractor.oper_mode == "Continuous"
+    assert extractor.in_flow == pytest.approx(_Inlet.mole_flow)
+
+    extractor.retrieve_results((
+        0.25,
+        np.array([0.4, 0.6]),
+        np.array([0.1, 0.9]),
+        {"error": 0.0, "num_iter": 1},
+    ))
+
+    assert not created["phase"]
+    assert len(created["stream"]) == 2
+    assert {tuple(outlet.amount) for outlet in created["stream"]} == {
+        ("mole_flow",),
+    }
+    stream_flows = sorted(outlet.amount["mole_flow"]
+                          for outlet in created["stream"])
+    assert stream_flows == pytest.approx([2.0, 6.0])
+    assert isinstance(extractor.Liquid_2, _DummyStream)
+    assert isinstance(extractor.Liquid_3, _DummyStream)
+
+
+def test_batch_extractor_keeps_batch_amount_semantics():
+    extractor = BatchExtractor()
+    extractor.Phases = _Inlet()
+
+    assert extractor.oper_mode == "Batch"
+    assert extractor.in_flow == pytest.approx(_Inlet.moles)

--- a/tests/test_extractor_modes.py
+++ b/tests/test_extractor_modes.py
@@ -1,3 +1,9 @@
+"""Regression tests for extractor operating-mode flow/amount routing.
+
+Continuous extraction should consume and return mole-flow rates [mol/s].
+Batch extraction should keep material amounts [mol].
+"""
+
 import numpy as np
 import pytest
 
@@ -9,25 +15,25 @@ pytestmark = pytest.mark.unit
 
 class _Inlet:
     name_species = ["solute", "solvent"]
-    mole_flow = 8.0
-    moles = 3.0
-    temp = 298.15
-    pres = 101325.0
-    mole_frac = np.array([0.25, 0.75])
+    mole_flow = 8.0  # mol/s
+    moles = 3.0  # mol
+    temp = 298.15  # K
+    pres = 101325.0  # Pa
+    mole_frac = np.array([0.25, 0.75])  # [-]
     path_data = "dummy-path"
 
 
 class _DummyOutlet:
     def __init__(self, path, mole_frac, temp, pres, **amount):
         self.path = path
-        self.mole_frac = mole_frac
-        self.temp = temp
-        self.pres = pres
-        self.amount = amount
+        self.mole_frac = mole_frac  # [-]
+        self.temp = temp  # K
+        self.pres = pres  # Pa
+        self.amount = amount  # mole_flow [mol/s] or moles [mol]
 
     def getDensity(self, basis):
         assert basis == "mole"
-        return 1000.0
+        return 1000.0  # arbitrary molar density [mol/m^3]
 
 
 class _DummyStream(_DummyOutlet):
@@ -39,6 +45,7 @@ class _DummyPhase(_DummyOutlet):
 
 
 def test_continuous_extractor_uses_mole_flow_and_stream_outlets(monkeypatch):
+    """Continuous extractor routes inlet and outlet quantities as mol/s."""
     created = {"stream": [], "phase": []}
 
     def stream_factory(*args, **kwargs):
@@ -61,9 +68,9 @@ def test_continuous_extractor_uses_mole_flow_and_stream_outlets(monkeypatch):
     assert extractor.in_flow == pytest.approx(_Inlet.mole_flow)
 
     extractor.retrieve_results((
-        0.25,
-        np.array([0.4, 0.6]),
-        np.array([0.1, 0.9]),
+        0.25,  # phase fraction [-]
+        np.array([0.4, 0.6]),  # liquid-a mole fractions [-]
+        np.array([0.1, 0.9]),  # liquid-b mole fractions [-]
         {"error": 0.0, "num_iter": 1},
     ))
 
@@ -80,6 +87,7 @@ def test_continuous_extractor_uses_mole_flow_and_stream_outlets(monkeypatch):
 
 
 def test_batch_extractor_keeps_batch_amount_semantics():
+    """Batch extractor keeps inlet amount semantics as mol."""
     extractor = BatchExtractor()
     extractor.Phases = _Inlet()
 


### PR DESCRIPTION
## Summary

Closes #53.

- Sets `ContinuousExtractor.oper_mode` to the repository's title-case `Continuous` mode so extractor inlet/result routing follows the continuous path.
- Updates extractor-internal continuous checks to the same `Continuous` convention and explicitly resets `BatchExtractor.oper_mode` to `Batch` after construction.
- Adds a focused regression test for continuous mole-flow routing and batch amount routing.

## Unit Contract

- Continuous extractor inputs use `mole_flow` in mol/s.
- `retrieve_results` splits the inlet flow by phase fraction, so the outlet values remain mol/s and are passed to `LiquidStream(..., mole_flow=...)`.
- Batch extractor inputs keep amount semantics through `moles` in mol and remain routed to `LiquidPhase(..., moles=...)`.

## Tests

- `conda run -n pharmapy python -m pytest tests/test_extractor_modes.py`
- `conda run -n pharmapy python -m pytest --collect-only`
- `conda run -n pharmapy python -m pytest tests/ --collect-only -m assimulo`
- `conda run -n pharmapy python -m pytest tests/ -m "not assimulo"`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check`

## Branch Hygiene

- Base branch: `master`
- Source branch point: `1a3ab3155216f07e9a18c60687a7b6b1c5959202`
- Stacked status: not stacked
- Prerequisites: none
- Open PR overlap: no open PRs were changing `PharmaPy/Extractors.py` or `tests/test_extractor_modes.py` during precheck
