### PR TITLE
Fix drying gas balance and state initialization

### DIFF
--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -217,9 +217,15 @@ class Drying:
         return dry_rates
 
     def unit_model(self, time, states, sw=None):
-        '''
-        state vector in the order: S|w_gas|w_liq|Tg|Ts
-        '''
+        """
+        Evaluate the drying model right-hand side.
+
+        The flattened per-node state order is
+        ``S | w_gas | w_liq | Tg | Ts``: saturation, gas and liquid mass
+        fractions are dimensionless ``[-]``; temperatures are ``[K]``.
+        The Darcy gas velocity computed here is a superficial velocity
+        ``[m/s]`` throttled by relative permeability ``k_ra [-]``.
+        """
 
         num_comp = self.Liquid_1.num_species
         states_reord = states.reshape(-1, 3 + num_comp + self.num_volatiles)
@@ -289,6 +295,16 @@ class Drying:
 
     def material_balance(self, time, satur, temp_gas, temp_sol, y_gas, x_liq,
                          u_gas, dens_gas, dry_rate, inputs, return_terms=False):
+        """
+        Return saturation, gas-fraction, and liquid-fraction derivatives.
+
+        ``satur``, ``y_gas``, and ``x_liq`` are dimensionless ``[-]``.
+        ``u_gas`` is the superficial gas velocity ``[m/s]`` and
+        ``dens_gas`` is gas density ``[kg/m**3]``. The gas transfer source
+        divides by the gas holdup only once through
+        ``epsilon_gas = porosity * (1 - satur)``; #21 / PR #108 owns the
+        separate drying-rate molar-to-mass basis conversion.
+        """
         
         satur[satur < eps] = eps
         satur[satur >= 1] = 1 - eps
@@ -416,6 +432,13 @@ class Drying:
 
     def solve_unit(self, deltaP, runtime=None, time_grid=None, any_event=True,
                    verbose=True, sundials_opts=None):
+        """
+        Initialize and integrate the drying model.
+
+        The initial per-node state vector is assembled as
+        ``S[-] | y_gas[-] | x_liq[-] | temp_gas[K] | temp_cond[K]`` for both
+        distributed and uniform single-node cake initial conditions.
+        """
         
         p_atm=101325
         # ---------- Initialization

--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -69,9 +69,9 @@ class Drying:
         self.T_ambient = 298
 
         # Transfer coefficients
-        self.k_y = 1e-3  # mol/s/m**2 (Seader, Separation process)
-        # self.h_T_j = 30  # W/m**2/K
-        self.h_T_j = 10  # W/m**2/K
+        self.k_y = 1e-3  # [mol/s/m**2] (Seader, Separation process)
+        # self.h_T_j = 30  # [W/m**2/K]
+        self.h_T_j = 10  # [W/m**2/K]
         self.h_T_loss = 30
 
         self._Phases = None
@@ -275,7 +275,11 @@ class Drying:
         Notes
         -----
         The Darcy gas velocity is a superficial velocity [m/s] throttled by
-        relative permeability ``k_ra`` [-].
+        relative permeability ``k_ra`` [-]. The relative-permeability Darcy
+        form is part of the #81 fix: the removed cake-resistance expression
+        bypassed ``k_ra`` and scaled by mean saturation instead. Its
+        dimensional check is ``k_perm`` [m**2] * ``k_ra`` [-] *
+        ``dPg_dz`` [Pa/m] / ``visc_gas`` [Pa*s] = [m/s].
         """
 
         num_comp = self.Liquid_1.num_species
@@ -296,9 +300,7 @@ class Drying:
         sat_red = (satur - self.s_inf) / (1 - self.s_inf)  # [-]
         sat_red = np.clip(sat_red, 0, 1)  # [-]
         k_ra = (1 - sat_red)**2 * (1 - sat_red**1.4)  # [-]
-        # Darcy velocity:
-        # k_perm [m**2] * k_ra [-] * dPg_dz [Pa/m] / visc_gas [Pa*s] = [m/s].
-        vel_gas = self.k_perm * k_ra * self.dPg_dz / visc_gas
+        vel_gas = self.k_perm * k_ra * self.dPg_dz / visc_gas  # [m/s]
         
         # ---------- Drying rate term
         mw_avg_gas = np.dot(y_gas, self.Vapor_1.mw)
@@ -338,9 +340,6 @@ class Drying:
                                           satur, y_gas, x_liq, vel_gas,
                                           rho_gas, self.dry_rate, inputs)
 
-        # print(satur.min())
-        # print(inputs.values())
-
         model_eqns = np.column_stack(material_eqns + energy_eqns)
 
         self.derivatives = model_eqns.ravel()
@@ -379,8 +378,10 @@ class Drying:
 
         Returns
         -------
-        list of ndarray
+        list of ndarray or int
             ``dsat_dt`` [1/s], ``dygas_dt`` [1/s], and ``dxliq_dt`` [1/s].
+            When ``return_terms`` is True, returns the legacy
+            ``masstrans_comp`` diagnostic flag [-].
 
         Notes
         -----
@@ -428,7 +429,7 @@ class Drying:
 
         dygas_dt = convection + transfer_gas + total_mass_correction  # [1/s]
 
-        if return_terms:    # TODO: check term by term in material balance down this line
+        if return_terms:
             self.masstrans_comp = 1
 
             return self.masstrans_comp
@@ -447,7 +448,7 @@ class Drying:
         # ----- Gas phase equations
         cpg_mix = self.Vapor_1.getCp(temp=temp_gas, mass_frac=y_gas,
                                      basis='mass')
-        cvg_mix = cpg_mix - gas_ct / mw_avg_gas * 1000  # J/kg K
+        cvg_mix = cpg_mix - gas_ct / mw_avg_gas * 1000  # [J/kg/K]
 
         epsilon_gas = self.porosity * (1 - satur)
         denom_gas = cvg_mix * epsilon_gas * rho_gas
@@ -482,8 +483,6 @@ class Drying:
         # Empty port
         # dTg_dt = -u_gas * dTg_dz + (-heat_loss) / denom_gas
         # dTg_dt =  (conv_term - heat_loss) / denom_gas
-
-        # print(dTg_dt[0])
 
         # ----- Condensed phases equations
         dens_liq = self.rho_liq
@@ -624,9 +623,9 @@ class Drying:
 
         # Mass transfer
         moments = self.Solid_1.getMoments(mom_num=[0, 1, 2, 3, 4])
-        sauter_diam = moments[1] / moments[0]  # m
+        sauter_diam = moments[1] / moments[0]  # [m]
 
-        # self.a_V = 6 / sauter_diam  # m**2/m**3
+        # self.a_V = 6 / sauter_diam  # [m**2/m**3]
         self.a_V = moments[2] * (1 - porosity) / moments[3]
         # Gas pressure
         # deltaP_media = deltaP*self.resist_medium / \
@@ -648,10 +647,10 @@ class Drying:
         csd = self.Solid_1.distrib# * 1e6
         mom_zero = self.Solid_1.moments[0]
 
-        # rholiq_mass = np.mean(rho_liq[0] * self.Liquid_1.mw_av[0])  # kg/m**3
+        # rholiq_mass = np.mean(rho_liq[0] * self.Liquid_1.mw_av[0])  # [kg/m**3]
         self.s_inf = get_sat_inf(x_csd, csd, deltaP, porosity,
                                  self.cake_height, mom_zero,
-                                 (np.mean(surf_tens), rho_liq[0]))#rholiq_mass))
+                                 (np.mean(surf_tens), rho_liq[0]))
 
         # ---------- Solve model
         model = self.unit_model

--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -239,9 +239,8 @@ class Drying:
         sat_red = (satur - self.s_inf) / (1 - self.s_inf)
         sat_red = np.maximum(0, sat_red)
         k_ra = (1 - sat_red)**2 * (1 - sat_red**1.4)
-        # vel_gas = self.k_perm * k_ra * self.dPg_dz / visc_gas
-        vel_gas = self.dPg_dz/ \
-        (self.CakePhase.alpha * visc_gas * self.rho_sol * (1 - self.porosity))/ np.mean(satur)
+        # Darcy velocity: [m**2] * [Pa/m] / [Pa*s] = [m/s].
+        vel_gas = self.k_perm * k_ra * self.dPg_dz / visc_gas
         
         # ---------- Drying rate term
         mw_avg_gas = np.dot(y_gas, self.Vapor_1.mw)
@@ -323,7 +322,8 @@ class Drying:
 
         convection = -u_gas * dygas_dz / epsilon_gas
         # Transfer term
-        transfer_gas = dry_rate.T / epsilon_gas / dens_gas/ (1 - satur)
+        # epsilon_gas already includes porosity*(1 - satur), the gas holdup.
+        transfer_gas = dry_rate.T / epsilon_gas / dens_gas
         # Dynamic saturation correction term
         total_mass_correction = y_gas.T / (1 - satur) * dsat_dt
 
@@ -460,8 +460,9 @@ class Drying:
                 states_prev = np.column_stack((satur_init, state_tiled))
                 
             else:
-                
-                states_tuple = (satur_init, y_gas_init, x_liq_init, temp_gas_init)
+
+                states_tuple = (satur_init, y_gas_init, x_liq_init,
+                                temp_gas_init, temp_cond_init)
     
                 states_stacked = np.hstack(states_tuple)
                 states_prev = np.tile(states_stacked, (self.num_nodes, 1))

--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -139,6 +139,19 @@ class Drying:
         self._Inlet = inlet
 
     def nomenclature(self):
+        """Create drying-model state metadata.
+
+        Returns
+        -------
+        None
+            The method populates inlet, outlet, state, and final-state metadata
+            on the instance.
+
+        Notes
+        -----
+        Saturation and mass fractions are dimensionless [-]. Gas and condensed
+        temperatures are tracked in [K].
+        """
         self.names_states_in = ['temp', 'mass_frac']
         self.names_states_out = self.names_states_in
 
@@ -152,17 +165,17 @@ class Drying:
         self.states_di = {
             'saturation': {# 'index': index_z,
                            'dim': 1,
-                           'units': '', 'type': 'diff'},
+                           'units': '[-]', 'type': 'diff'},
             'y_gas': {'index': self.name_species,
-                      'dim': len(self.name_species), 'units': '',
+                      'dim': len(self.name_species), 'units': '[-]',
                       'type': 'diff'},
-            'x_liq': {'index': name_liq, 'dim': len(name_liq), 'units': '',
+            'x_liq': {'index': name_liq, 'dim': len(name_liq), 'units': '[-]',
                       'type': 'diff'},
             'temp_gas': {# 'index': index_z,
-                         'dim': 1, 'units': 'K',
+                         'dim': 1, 'units': '[K]',
                          'type': 'diff'},
             'temp_cond': {# 'index': index_z,
-                         'dim': 1, 'units': 'K',
+                         'dim': 1, 'units': '[K]',
                          'type': 'diff'},
             }
 
@@ -282,20 +295,21 @@ class Drying:
         ``dPg_dz`` [Pa/m] / ``visc_gas`` [Pa*s] = [m/s].
         """
 
-        num_comp = self.Liquid_1.num_species
-        states_reord = states.reshape(-1, 3 + num_comp + self.num_volatiles)
+        num_comp = self.Liquid_1.num_species  # [-]
+        states_reord = states.reshape(
+            -1, 3 + num_comp + self.num_volatiles)  # [-] and [K]
 
-        satur = states_reord[:, 0]
-        y_gas = states_reord[:, 1:1 + num_comp]
+        satur = states_reord[:, 0]  # [-]
+        y_gas = states_reord[:, 1:1 + num_comp]  # [-]
         x_liq = states_reord[:, 1 + num_comp:
-                             1 + num_comp + self.num_volatiles]
-        x_liq[:, -2] = 0
-        temp_gas = states_reord[:, -2]
-        temp_sol = states_reord[:, -1]
+                             1 + num_comp + self.num_volatiles]  # [-]
+        x_liq[:, -2] = 0  # [-]
+        temp_gas = states_reord[:, -2]  # [K]
+        temp_sol = states_reord[:, -1]  # [K]
 
         # ---------- Darcy's equation
         visc_gas = self.Vapor_1.getViscosity(temp=temp_gas,
-                                             mass_frac=y_gas)
+                                             mass_frac=y_gas)  # [Pa*s]
 
         sat_red = (satur - self.s_inf) / (1 - self.s_inf)  # [-]
         sat_red = np.clip(sat_red, 0, 1)  # [-]
@@ -303,21 +317,20 @@ class Drying:
         vel_gas = self.k_perm * k_ra * self.dPg_dz / visc_gas  # [m/s]
         
         # ---------- Drying rate term
-        mw_avg_gas = np.dot(y_gas, self.Vapor_1.mw)
+        mw_avg_gas = np.dot(y_gas, self.Vapor_1.mw)  # [g/mol]
         rho_gas = self.pres_gas / gas_ct / temp_gas * mw_avg_gas / 1000  # [kg/m**3]
         rho_liq_ = self.Liquid_1.rho_liq[self.idx_volatiles]  # [kg/m**3]
         self.rho_liq =  1 / np.sum((x_liq/ rho_liq_), axis=1)  # [kg/m**3]
         # Dry correction
         if self.mass_eta:
-            rho_liq = self.rho_liq
-            
+            rho_liq = self.rho_liq  # [kg/m**3]
+
             sat_eta = (self.porosity * satur * rho_liq)/ \
-                ((1 - self.porosity) * self.rho_sol + self.porosity * satur *rho_liq)
-            # sat_eta = satur * rho_liq / (satur*rho_liq + (1 - satur)*rho_gas)
-            w_eta = x_liq
+                ((1 - self.porosity) * self.rho_sol + self.porosity * satur *rho_liq)  # [-]
+            w_eta = x_liq  # [-]
         else:
-            sat_eta = satur
-            w_eta = x_liq
+            sat_eta = satur  # [-]
+            w_eta = x_liq  # [-]
 
         limiter_factor = self.eta_fun(sat_eta, w_eta)  # [-]
 
@@ -327,22 +340,22 @@ class Drying:
 
         # Balances below consume mass-basis drying rates [kg/m**3/s].
         self.dry_rate = self._drying_rate_mass_basis(self.dry_rate)
-        self.dry_rate *= limiter_factor[..., np.newaxis]
+        self.dry_rate *= limiter_factor[..., np.newaxis]  # [kg/m**3/s]
 
         # ---------- Model equations
-        inputs = self.get_inputs(time)['Inlet']
+        inputs = self.get_inputs(time)['Inlet']  # inlet states: [-] and [K]
 
         material_eqns = self.material_balance(
             time, satur, temp_gas, temp_sol, y_gas, x_liq,
-            vel_gas, rho_gas, self.dry_rate, inputs)
+            vel_gas, rho_gas, self.dry_rate, inputs)  # [1/s]
 
         energy_eqns = self.energy_balance(time, temp_gas, temp_sol,
                                           satur, y_gas, x_liq, vel_gas,
-                                          rho_gas, self.dry_rate, inputs)
+                                          rho_gas, self.dry_rate, inputs)  # [K/s]
 
-        model_eqns = np.column_stack(material_eqns + energy_eqns)
+        model_eqns = np.column_stack(material_eqns + energy_eqns)  # [1/s, K/s]
 
-        self.derivatives = model_eqns.ravel()
+        self.derivatives = model_eqns.ravel()  # [1/s, K/s]
 
         return model_eqns.ravel()
 
@@ -439,72 +452,118 @@ class Drying:
 
     def energy_balance(self, time, temp_gas, temp_sol, satur, y_gas, x_liq,
                        u_gas, rho_gas, dry_rate, inputs, return_terms=False):
+        """Evaluate gas and condensed-phase energy balances.
 
-        # temp_ref = 298
-        mw_avg_gas = np.dot(y_gas, self.Vapor_1.mw)
+        Parameters
+        ----------
+        time : float
+            Current integration time [s].
+        temp_gas : ndarray
+            Gas-phase temperature by spatial node [K].
+        temp_sol : ndarray
+            Condensed-phase temperature by spatial node [K].
+        satur : ndarray
+            Cake saturation by spatial node [-].
+        y_gas : ndarray
+            Gas-phase mass fractions by node and species [-].
+        x_liq : ndarray
+            Liquid mass fractions by node and volatile species [-].
+        u_gas : ndarray
+            Gas velocity by spatial node [m/s].
+        rho_gas : ndarray
+            Gas density by spatial node [kg/m**3].
+        dry_rate : ndarray
+            Component drying rates on a mass basis [kg/m**3/s].
+        inputs : dict
+            Inlet condition dictionary; ``temp`` is the gas inlet
+            temperature [K].
+        return_terms : bool, optional
+            Return stored diagnostic terms instead of temperature derivatives [-].
+
+        Returns
+        -------
+        list of ndarray
+            ``dTg_dt`` and ``dTcond_dt`` by spatial node [K/s] when
+            ``return_terms`` is False.
+        tuple of ndarray
+            When ``return_terms`` is True, returns the diagnostic terms
+            ``(convec_term, drying, heat_cond, heat_loss_emp)`` instead.
+            ``convec_term`` is the raw ``u_gas * dTg_dz`` diagnostic
+            [kg*K/m**3/s]; the remaining entries are gas-temperature-rate
+            contributions [K/s].
+
+        Notes
+        -----
+        This branch fixes the gas material-balance holdup denominator. The
+        legacy latent-heat factor in ``drying_terms`` is left unchanged here;
+        PR #124 owns that scoped correction. The existing gas-convection
+        discretization is also preserved; ``dTg_dz`` [kg*K/m**4] and
+        ``conv_term`` [J*kg/m**6/s] are annotated as implemented so that the
+        remaining dimensional debt is explicit without expanding this branch's
+        behavior change.
+        """
+
+        mw_avg_gas = np.dot(y_gas, self.Vapor_1.mw)  # [g/mol]
         # ----- Reading inputs
-        temp_gas_inputs = inputs['temp']
+        temp_gas_inputs = inputs['temp']  # [K]
 
         # ----- Gas phase equations
         cpg_mix = self.Vapor_1.getCp(temp=temp_gas, mass_frac=y_gas,
-                                     basis='mass')
+                                     basis='mass')  # [J/kg/K]
         cvg_mix = cpg_mix - gas_ct / mw_avg_gas * 1000  # [J/kg/K]
 
-        epsilon_gas = self.porosity * (1 - satur)
-        denom_gas = cvg_mix * epsilon_gas * rho_gas
+        epsilon_gas = self.porosity * (1 - satur)  # [-]
+        denom_gas = cvg_mix * epsilon_gas * rho_gas  # [J/m**3/K]
 
         latent_heat = self.Vapor_1.getHeatVaporization(temp_sol,
-                                                       basis='mass')
+                                                       basis='mass')  # [J/kg]
 
         xliq_extended = np.column_stack((x_liq, np.zeros((x_liq.shape[0],
-                                                          len(self.idx_supercrit)))))
+                                                          len(self.idx_supercrit)))))  # [-]
 
         cpl_mix = self.Liquid_1.getCp(temp=temp_sol, mass_frac=xliq_extended,
-                                      basis='mass')
-        temp_wb = 22+273
-        sensible_heat = cpg_mix * (temp_gas - temp_wb) * dry_rate.sum(axis=1)
-        
-        heat_transf = self.h_T_j * self.a_V * (temp_gas - temp_sol)
-        drying_terms = rho_gas / self.rho_liq * cpg_mix
+                                      basis='mass')  # [J/kg/K]
+        temp_wb = 22+273  # [K]
+        sensible_heat = cpg_mix * (temp_gas - temp_wb) * dry_rate.sum(axis=1)  # [J/m**3/s]
+
+        heat_transf = self.h_T_j * self.a_V * (temp_gas - temp_sol)  # [J/m**3/s]
+        drying_terms = rho_gas / self.rho_liq * cpg_mix  # [J/kg/K]
         # heat_loss = self.h_T_loss * self.a_V * (temp_gas - self.T_ambient)
-        heat_loss = self.h_T_loss * self.cake_height * (2*np.pi*1.5/2/100) *(temp_gas - self.T_ambient)
-        heat_loss = 0  # This line is for assumption of no heat loss
+        heat_loss = (
+            self.h_T_loss * self.cake_height * (2*np.pi*1.5/2/100) *
+            (temp_gas - self.T_ambient)
+        )  # [J/s]
+        heat_loss = 0  # [J/m**3/s], assumption of no heat loss.
         fluxes_Tg = high_resolution_fvm(temp_gas,
-                                        boundary_cond=temp_gas_inputs)
-        
-        # fluxes_Tg = upwind_fvm(temp_gas, boundary_cond=temp_gas_inputs)
-        # sensible_heat = cpg_mix * np.diff(fluxes_Tg) * dry_rate.sum(axis=1)
-        dTg_dz = np.diff(fluxes_Tg) / self.dz * epsilon_gas * rho_gas
+                                        boundary_cond=temp_gas_inputs)  # [K]
 
-        conv_term = -u_gas * dTg_dz * cpg_mix * rho_gas
+        dTg_dz = np.diff(fluxes_Tg) / self.dz * epsilon_gas * rho_gas  # [kg*K/m**4]
 
-        dTg_dt = (conv_term + sensible_heat - heat_transf - heat_loss) / denom_gas
-        
-        # Empty port
-        # dTg_dt = -u_gas * dTg_dz + (-heat_loss) / denom_gas
-        # dTg_dt =  (conv_term - heat_loss) / denom_gas
+        conv_term = -u_gas * dTg_dz * cpg_mix * rho_gas  # [J*kg/m**6/s]
+
+        dTg_dt = (conv_term + sensible_heat - heat_transf - heat_loss) / denom_gas  # [K/s]
 
         # ----- Condensed phases equations
-        dens_liq = self.rho_liq
+        dens_liq = self.rho_liq  # [kg/m**3]
         # heat_loss_cond = self.h_T_loss * self.a_V * (temp_sol - self.T_ambient)
-        heat_loss_cond = self.h_T_loss * self.cake_height * (2*np.pi*1.5/2/100) *(temp_sol - self.T_ambient)
-        heat_loss_cond = 0
-        drying_terms = (dry_rate[:, self.idx_volatiles] * latent_heat * 2).sum(axis=1)
+        heat_loss_cond = (
+            self.h_T_loss * self.cake_height * (2*np.pi*1.5/2/100) *
+            (temp_sol - self.T_ambient)
+        )  # [J/s]
+        heat_loss_cond = 0  # [J/m**3/s], assumption of no heat loss.
+        drying_terms = (
+            dry_rate[:, self.idx_volatiles] * latent_heat * 2
+        ).sum(axis=1)  # [J/m**3/s]
         denom_cond = self.rho_sol * (1 - self.porosity) * self.cp_sol + \
-            self.porosity * satur * cpl_mix * dens_liq
+            self.porosity * satur * cpl_mix * dens_liq  # [J/m**3/K]
 
-        dTcond_dt = (-drying_terms + heat_transf - heat_loss_cond) / denom_cond
-        
-        ## ---- Trial for lumping both cond/gas phase into one
-        # dTtotal_dt = (conv_term + sensible_heat - drying_terms - heat_loss_cond)/ (denom_gas + denom_cond)
-        
-        # dTg_dt, dTcond_dt = dTtotal_dt, dTtotal_dt
-        
+        dTcond_dt = (-drying_terms + heat_transf - heat_loss_cond) / denom_cond  # [K/s]
+
         if return_terms:
-            self.convec_term = u_gas * dTg_dz
-            self.drying = drying_terms/ denom_gas
-            self.heat_cond = heat_transf/ denom_gas
-            self.heat_loss_emp = heat_loss/ denom_gas
+            self.convec_term = u_gas * dTg_dz  # [kg*K/m**3/s]
+            self.drying = drying_terms/ denom_gas  # [K/s]
+            self.heat_cond = heat_transf/ denom_gas  # [K/s]
+            self.heat_loss_emp = heat_loss/ denom_gas  # [K/s]
 
             return self.convec_term, self.drying, self.heat_cond, self.heat_loss_emp
 
@@ -518,7 +577,8 @@ class Drying:
         Initialize and integrate the drying model.
 
         The initial per-node state vector is assembled as
-        ``S[-] | y_gas[-] | x_liq[-] | temp_gas[K] | temp_cond[K]`` for both
+        ``S`` [-] | ``y_gas`` [-] | ``x_liq`` [-] | ``temp_gas`` [K] |
+        ``temp_cond`` [K] for both
         distributed and uniform single-node cake initial conditions.
         """
         

--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -24,9 +24,9 @@ from PharmaPy.Connections import get_inputs_new
 from PharmaPy.Results import DynamicResult
 from PharmaPy.Plotting import plot_distrib
 
-eps = np.finfo(float).eps
+eps = np.finfo(float).eps  # [-]
 
-gas_ct = 8.314
+gas_ct = 8.314  # [J/mol/K]
 
 
 class Drying:
@@ -62,17 +62,17 @@ class Drying:
         """
         self.supercrit_names = supercrit_names
 
-        self.num_nodes = number_nodes
-        self.station_diameter = diam_unit
-        self.area_cross = self.station_diameter**2 * np.pi/4
-        self.resist_medium = resist_medium
-        self.T_ambient = 298
+        self.num_nodes = number_nodes  # [-]
+        self.station_diameter = diam_unit  # [m]
+        self.area_cross = self.station_diameter**2 * np.pi/4  # [m**2]
+        self.resist_medium = resist_medium  # [1/m]
+        self.T_ambient = 298  # [K]
 
         # Transfer coefficients
         self.k_y = 1e-3  # [mol/s/m**2] (Seader, Separation process)
         # self.h_T_j = 30  # [W/m**2/K]
         self.h_T_j = 10  # [W/m**2/K]
-        self.h_T_loss = 30
+        self.h_T_loss = 30  # [W/m**2/K]
 
         self._Phases = None
         self._Inlet = None
@@ -88,7 +88,7 @@ class Drying:
         self.state_event_list = state_events
 
         self.outputs = None
-        self.elapsed_time = 0
+        self.elapsed_time = 0  # [s]
 
     @property
     def Phases(self):
@@ -199,17 +199,33 @@ class Drying:
         return events
 
     def get_y_equilib(self, temp_cond, x_liq, p_gas):
-        mw_liq = self.Liquid_1.mw[self.idx_volatiles]
+        """Calculate equilibrium gas mole fractions above the liquid.
+
+        Parameters
+        ----------
+        temp_cond : ndarray
+            Condensed-phase temperature by spatial node [K].
+        x_liq : ndarray
+            Liquid mass fractions for volatile components [-].
+        p_gas : ndarray or float
+            Gas pressure [Pa].
+
+        Returns
+        -------
+        ndarray
+            Equilibrium gas mole fractions for volatile components [-].
+        """
+        mw_liq = self.Liquid_1.mw[self.idx_volatiles]  # [g/mol]
         x_liq_mole_frac = (x_liq / mw_liq).T / np.dot(1/mw_liq, x_liq.T)
-        x_liq_mole_frac = x_liq_mole_frac.T
+        x_liq_mole_frac = x_liq_mole_frac.T  # [-]
 
-        p_sat = self.Liquid_1.AntoineEquation(temp=temp_cond)
+        p_sat = self.Liquid_1.AntoineEquation(temp=temp_cond)  # [Pa]
 
-        gamma = self.Liquid_1.getActivityCoeff(mole_frac=x_liq_mole_frac)
+        gamma = self.Liquid_1.getActivityCoeff(mole_frac=x_liq_mole_frac)  # [-]
         # p_gas_total = np.sum(x_liq_mole_frac * p_sat[:, self.idx_volatiles],
         #                      axis=1)
-        p_partial = (gamma * x_liq_mole_frac * p_sat[:, self.idx_volatiles]).T
-        y_equil = p_partial  / p_gas
+        p_partial = (gamma * x_liq_mole_frac * p_sat[:, self.idx_volatiles]).T  # [Pa]
+        y_equil = p_partial  / p_gas  # [-]
 
         return y_equil
 
@@ -293,6 +309,12 @@ class Drying:
         bypassed ``k_ra`` and scaled by mean saturation instead. Its
         dimensional check is ``k_perm`` [m**2] * ``k_ra`` [-] *
         ``dPg_dz`` [Pa/m] / ``visc_gas`` [Pa*s] = [m/s].
+
+        The gas-density path still uses the legacy mass-fraction weighted
+        molecular-weight surrogate [g/mol]; issue #28 owns replacing it with
+        the true mixture molecular weight. The ``x_liq`` supercritical slot
+        reset preserves the existing state layout; issue #42 owns replacing
+        the magic index with explicit metadata.
         """
 
         num_comp = self.Liquid_1.num_species  # [-]
@@ -303,7 +325,7 @@ class Drying:
         y_gas = states_reord[:, 1:1 + num_comp]  # [-]
         x_liq = states_reord[:, 1 + num_comp:
                              1 + num_comp + self.num_volatiles]  # [-]
-        x_liq[:, -2] = 0  # [-]
+        x_liq[:, -2] = 0  # legacy supercritical component slot [-]
         temp_gas = states_reord[:, -2]  # [K]
         temp_sol = states_reord[:, -1]  # [K]
 
@@ -317,7 +339,7 @@ class Drying:
         vel_gas = self.k_perm * k_ra * self.dPg_dz / visc_gas  # [m/s]
         
         # ---------- Drying rate term
-        mw_avg_gas = np.dot(y_gas, self.Vapor_1.mw)  # [g/mol]
+        mw_avg_gas = np.dot(y_gas, self.Vapor_1.mw)  # legacy MW surrogate [g/mol]
         rho_gas = self.pres_gas / gas_ct / temp_gas * mw_avg_gas / 1000  # [kg/m**3]
         rho_liq_ = self.Liquid_1.rho_liq[self.idx_volatiles]  # [kg/m**3]
         self.rho_liq =  1 / np.sum((x_liq/ rho_liq_), axis=1)  # [kg/m**3]
@@ -483,14 +505,16 @@ class Drying:
         Returns
         -------
         list of ndarray
-            ``dTg_dt`` and ``dTcond_dt`` by spatial node [K/s] when
-            ``return_terms`` is False.
+            ``dTcond_dt`` by spatial node [K/s] and the legacy gas-temperature
+            solver channel ``dTg_dt`` when ``return_terms`` is False. Issue #37
+            owns the gas-convection dimensional correction.
         tuple of ndarray
             When ``return_terms`` is True, returns the diagnostic terms
             ``(convec_term, drying, heat_cond, heat_loss_emp)`` instead.
             ``convec_term`` is the raw ``u_gas * dTg_dz`` diagnostic
-            [kg*K/m**3/s]; the remaining entries are gas-temperature-rate
-            contributions [K/s].
+            [kg*K/m**3/s]. ``drying`` preserves the legacy diagnostic
+            denominator on this branch; PR #124 owns the condensed latent-heat
+            diagnostic correction.
 
         Notes
         -----
@@ -503,7 +527,7 @@ class Drying:
         behavior change.
         """
 
-        mw_avg_gas = np.dot(y_gas, self.Vapor_1.mw)  # [g/mol]
+        mw_avg_gas = np.dot(y_gas, self.Vapor_1.mw)  # legacy MW surrogate [g/mol]
         # ----- Reading inputs
         temp_gas_inputs = inputs['temp']  # [K]
 
@@ -527,13 +551,7 @@ class Drying:
         sensible_heat = cpg_mix * (temp_gas - temp_wb) * dry_rate.sum(axis=1)  # [J/m**3/s]
 
         heat_transf = self.h_T_j * self.a_V * (temp_gas - temp_sol)  # [J/m**3/s]
-        drying_terms = rho_gas / self.rho_liq * cpg_mix  # [J/kg/K]
-        # heat_loss = self.h_T_loss * self.a_V * (temp_gas - self.T_ambient)
-        heat_loss = (
-            self.h_T_loss * self.cake_height * (2*np.pi*1.5/2/100) *
-            (temp_gas - self.T_ambient)
-        )  # [J/s]
-        heat_loss = 0  # [J/m**3/s], assumption of no heat loss.
+        heat_loss = np.zeros_like(temp_gas)  # [J/m**3/s]
         fluxes_Tg = high_resolution_fvm(temp_gas,
                                         boundary_cond=temp_gas_inputs)  # [K]
 
@@ -541,16 +559,13 @@ class Drying:
 
         conv_term = -u_gas * dTg_dz * cpg_mix * rho_gas  # [J*kg/m**6/s]
 
-        dTg_dt = (conv_term + sensible_heat - heat_transf - heat_loss) / denom_gas  # [K/s]
+        dTg_dt = (
+            conv_term + sensible_heat - heat_transf - heat_loss
+        ) / denom_gas  # legacy solver output [K/s]; issue #37 owns units.
 
         # ----- Condensed phases equations
         dens_liq = self.rho_liq  # [kg/m**3]
-        # heat_loss_cond = self.h_T_loss * self.a_V * (temp_sol - self.T_ambient)
-        heat_loss_cond = (
-            self.h_T_loss * self.cake_height * (2*np.pi*1.5/2/100) *
-            (temp_sol - self.T_ambient)
-        )  # [J/s]
-        heat_loss_cond = 0  # [J/m**3/s], assumption of no heat loss.
+        heat_loss_cond = np.zeros_like(temp_sol)  # [J/m**3/s]
         drying_terms = (
             dry_rate[:, self.idx_volatiles] * latent_heat * 2
         ).sum(axis=1)  # [J/m**3/s]
@@ -573,16 +588,42 @@ class Drying:
 
     def solve_unit(self, deltaP, runtime=None, time_grid=None, any_event=True,
                    verbose=True, sundials_opts=None):
-        """
-        Initialize and integrate the drying model.
+        """Initialize and integrate the drying model.
 
+        Parameters
+        ----------
+        deltaP : float
+            Pressure drop across the drying cake and medium [Pa].
+        runtime : float, optional
+            Duration to simulate from the current elapsed time [s].
+        time_grid : ndarray, optional
+            Output time grid for the CVode simulation [s].
+        any_event : bool, optional
+            Whether any configured state event can terminate the solve [-].
+        verbose : bool, optional
+            If False, suppress solver output [-].
+        sundials_opts : dict, optional
+            Solver option names and values forwarded to CVode.
+
+        Returns
+        -------
+        time : ndarray
+            Simulated time points [s].
+        states : ndarray
+            Flattened state history. Saturation and mass-fraction columns are
+            dimensionless [-]; temperature columns are [K].
+
+        Notes
+        -----
         The initial per-node state vector is assembled as
         ``S`` [-] | ``y_gas`` [-] | ``x_liq`` [-] | ``temp_gas`` [K] |
         ``temp_cond`` [K] for both
         distributed and uniform single-node cake initial conditions.
+        Cake permeability is computed as
+        ``1 / (alpha * rho_sol * (1 - porosity))`` [m**2].
         """
         
-        p_atm=101325
+        p_atm=101325  # [Pa]
         # ---------- Initialization
         # Volatile components
         idx_liquid = np.arange(0, self.Liquid_1.num_species)
@@ -603,15 +644,15 @@ class Drying:
         # y_gas_init = np.tile(self.Vapor_1.mole_frac, (self.num_nodes,1))
         # x_liq_init = self.CakePhase.Liquid_1.mole_frac[:, idx_volatiles]
 
-        y_gas_init = self.Vapor_1.mass_frac
-        x_liq_init = self.CakePhase.Liquid_1.mass_frac
+        y_gas_init = self.Vapor_1.mass_frac  # [-]
+        x_liq_init = self.CakePhase.Liquid_1.mass_frac  # [-]
 
-        satur_init = self.CakePhase.saturation
+        satur_init = self.CakePhase.saturation  # [-]
 
         # Temperatures
-        temp_cond_init = self.CakePhase.Solid_1.temp
-        temp_gas_init = self.Vapor_1.temp
-        z_cake = self.CakePhase.z_external  # For drying_script_inyoung
+        temp_cond_init = self.CakePhase.Solid_1.temp  # [K]
+        temp_gas_init = self.Vapor_1.temp  # [K]
+        z_cake = self.CakePhase.z_external  # [m], for drying_script_inyoung
         # z_cake = self.CakePhase.z_external # This line for 2MSMPR_Filter.py
 
         if x_liq_init.ndim == 1:
@@ -661,9 +702,9 @@ class Drying:
         #z_cake = self.cake_height * self.CakePhase.z_external
 
         # Physical properties
-        alpha = self.CakePhase.alpha
-        rho_sol = self.Solid_1.getDensity()
-        porosity = self.CakePhase.porosity
+        alpha = self.CakePhase.alpha  # [m/kg]
+        rho_sol = self.Solid_1.getDensity()  # [kg/m**3]
+        porosity = self.CakePhase.porosity  # [-]
 
         xliq = states_prev[:, num_comp + 1: num_comp + 1 + self.num_volatiles]
         # xliq = states_init[:, num_comp + 1: num_comp + 1 + self.num_volatiles]
@@ -671,36 +712,36 @@ class Drying:
         xliq_init = np.zeros((self.num_nodes, num_comp))
         xliq_init[:, self.idx_volatiles] = xliq
         rho_liq = self.Liquid_1.getDensity(temp=temp_cond_init,
-                                           mass_frac=xliq_init, basis='mass')
+                                           mass_frac=xliq_init, basis='mass')  # [kg/m**3]
         surf_tens = self.Liquid_1.getSurfTension(temp=temp_cond_init,
-                                                 mass_frac=xliq_init)
+                                                 mass_frac=xliq_init)  # [N/m]
 
-        self.k_perm = 1 / alpha / rho_sol / (1 - porosity)
+        self.k_perm = 1 / alpha / rho_sol / (1 - porosity)  # [m**2]
         # self.rho_liq = rho_liq
         self.rho_sol = rho_sol
         self.porosity = porosity
-        self.cp_sol = self.Solid_1.getCp()
+        self.cp_sol = self.Solid_1.getCp()  # [J/kg/K]
 
         # Mass transfer
         moments = self.Solid_1.getMoments(mom_num=[0, 1, 2, 3, 4])
         sauter_diam = moments[1] / moments[0]  # [m]
 
         # self.a_V = 6 / sauter_diam  # [m**2/m**3]
-        self.a_V = moments[2] * (1 - porosity) / moments[3]
+        self.a_V = moments[2] * (1 - porosity) / moments[3]  # [m**2/m**3]
         # Gas pressure
         # deltaP_media = deltaP*self.resist_medium / \
         #     (alpha*rho_sol*self.cake_height + self.resist_medium)
 
         deltaP_media = deltaP*self.resist_medium / \
             (alpha*rho_sol*(1 - porosity)*self.cake_height +
-              self.resist_medium)
-        deltaP -= deltaP_media
-        self.deltaP = deltaP
-        p_top = p_atm + deltaP
+              self.resist_medium)  # [Pa]
+        deltaP -= deltaP_media  # [Pa]
+        self.deltaP = deltaP  # [Pa]
+        p_top = p_atm + deltaP  # [Pa]
 
-        self.dPg_dz = deltaP / self.cake_height
+        self.dPg_dz = deltaP / self.cake_height  # [Pa/m]
         self.pres_gas = np.linspace(p_top, p_top - deltaP,
-                                    num=self.num_nodes)
+                                    num=self.num_nodes)  # [Pa]
 
         # Irreducible saturation
         x_csd = self.Solid_1.x_distrib #* 1e-6
@@ -710,7 +751,7 @@ class Drying:
         # rholiq_mass = np.mean(rho_liq[0] * self.Liquid_1.mw_av[0])  # [kg/m**3]
         self.s_inf = get_sat_inf(x_csd, csd, deltaP, porosity,
                                  self.cake_height, mom_zero,
-                                 (np.mean(surf_tens), rho_liq[0]))
+                                 (np.mean(surf_tens), rho_liq[0]))  # [-]
 
         # ---------- Solve model
         model = self.unit_model
@@ -759,6 +800,21 @@ class Drying:
         return time, states
 
     def retrieve_results(self, time, states):
+        """Store drying simulation outputs in a ``DynamicResult``.
+
+        Parameters
+        ----------
+        time : array_like
+            Simulated time points [s].
+        states : ndarray
+            Flattened state history. Saturation and mass-fraction columns are
+            dimensionless [-]; temperature columns are [K].
+
+        Returns
+        -------
+        None
+            The method updates ``result`` and cake-grid metadata in place.
+        """
         time = np.array(time)
         self.timeProf = time
         self.elapsed_time += time[-1]
@@ -779,6 +835,13 @@ class Drying:
         self.CakePhase.z_external = self.z_centers
 
     def flatten_states(self):
+        """Placeholder for future drying-state flattening support.
+
+        Returns
+        -------
+        None
+            This method is not implemented.
+        """
         pass
 
     def plot_profiles(self, times=None, z_pos=None, pick_comp=None, **fig_kw):
@@ -862,6 +925,22 @@ class Drying:
         return fig, axes
 
     def plot_rates(self, z_pos=0, fig_size=None):
+        """Plot drying rates at one axial position.
+
+        Parameters
+        ----------
+        z_pos : float, optional
+            Axial position used to select the nearest drying node [m].
+        fig_size : tuple, optional
+            Figure size forwarded to matplotlib [-].
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+            Created figure.
+        axis : matplotlib.axes.Axes
+            Axes containing drying-rate profiles [mol/m**3/s].
+        """
         z_idx = np.argmin(abs(z_pos - self.z_centers))
         temp_cond = self.tempLiqProf[:, z_idx]
 

--- a/PharmaPy/Drying_Model.py
+++ b/PharmaPy/Drying_Model.py
@@ -243,7 +243,7 @@ class Drying:
                                              mass_frac=y_gas)
 
         sat_red = (satur - self.s_inf) / (1 - self.s_inf)
-        sat_red = np.maximum(0, sat_red)
+        sat_red = np.clip(sat_red, 0, 1)
         k_ra = (1 - sat_red)**2 * (1 - sat_red**1.4)
         # Darcy velocity: [m**2] * [Pa/m] / [Pa*s] = [m/s].
         vel_gas = self.k_perm * k_ra * self.dPg_dz / visc_gas

--- a/PharmaPy/Plotting.py
+++ b/PharmaPy/Plotting.py
@@ -64,6 +64,37 @@ def latexify_name(name, units=False):
     return out
 
 
+def format_unit_label(units):
+    """Return a display label for unit metadata.
+
+    Parameters
+    ----------
+    units : str or None
+        Unit metadata. Bracketed values such as ``[K]`` and ``[-]`` follow the
+        repository documentation convention.
+
+    Returns
+    -------
+    str
+        LaTeX-formatted unit label without metadata brackets. Dimensionless
+        metadata ``[-]`` and empty values return an empty string.
+    """
+    if units is None:
+        return ''
+
+    units = str(units).strip()
+    if units == '':
+        return ''
+
+    if units.startswith('[') and units.endswith(']'):
+        units = units[1:-1].strip()
+
+    if units in ('', '-'):
+        return ''
+
+    return latexify_name(units, units=True)
+
+
 def color_axis(ax, color):
     ax.spines['right'].set_color(color)
     ax.tick_params(axis='y', colors=color, which='both')
@@ -182,8 +213,8 @@ def name_yaxes(ax, states_fstates, names, ylabels, legend):
             ylabel = latexify_name(ylabels[ind])
 
         units = states_fstates[name].get('units', '')
-        if len(units) > 0:
-            unit_name = latexify_name(units, units=True)
+        unit_name = format_unit_label(units)
+        if len(unit_name) > 0:
             ylabel = ylabel + ' (' + unit_name + ')'
 
         axis.set_ylabel(ylabel)
@@ -265,9 +296,8 @@ def plot_function(uo, state_names, axes=None, fig_map=None, ylabels=None,
             ylabel = latexify_name(ylabels[ind])
 
         units = states_and_fstates[name].get('units', '')
-        if len(units) > 0:
-            unit_name = latexify_name(states_and_fstates[name]['units'],
-                                      units=True)
+        unit_name = format_unit_label(units)
+        if len(unit_name) > 0:
             ylabel = ylabel + ' (' + unit_name + ')'
 
         if index_y:

--- a/tests/test_drying_energy_rate_basis.py
+++ b/tests/test_drying_energy_rate_basis.py
@@ -110,14 +110,14 @@ def test_unit_model_uses_mass_drying_rate_in_energy_terms(monkeypatch):
     derivatives = derivatives.reshape(3, -1)
 
     # Sensible power [J/m**3/s] divided by gas capacity [J/m**3/K].
-    # power = cp_gas [J/kg/K] * (T_gas - 295 K) * sum(m_dot_i) [kg/m**3/s].
+    # power = cp_gas [J/kg/K] * (T_gas - 295 [K]) * sum(m_dot_i) [kg/m**3/s].
     expected_gas_temperature_rate = np.array([
         1100.0 / 450.0,
         3408.0 / 1100.0,
         2475.0 / 700.0,
     ])  # [K/s]
 
-    # The mass-rate latent powers are [256000, 338000, 128000] J/m**3/s. Issue #24
+    # The mass-rate latent powers are [256000, 338000, 128000] [J/m**3/s]. Issue #24
     # separately tracks the existing factor of two applied to those powers.
     expected_condensed_temperature_rate = np.array([
         -512000.0 / 900000.0,

--- a/tests/test_drying_gas_balance.py
+++ b/tests/test_drying_gas_balance.py
@@ -1,0 +1,216 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+import numpy as np
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def _stub_assimulo_modules(monkeypatch):
+    assimulo = ModuleType("assimulo")
+
+    class ExplicitProblem:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    solvers = ModuleType("assimulo.solvers")
+    solvers.CVode = object
+
+    problem = ModuleType("assimulo.problem")
+    problem.Explicit_Problem = ExplicitProblem
+
+    monkeypatch.setitem(sys.modules, "assimulo", assimulo)
+    monkeypatch.setitem(sys.modules, "assimulo.solvers", solvers)
+    monkeypatch.setitem(sys.modules, "assimulo.problem", problem)
+
+
+def _import_drying_model(monkeypatch):
+    try:
+        from PharmaPy import Drying_Model
+    except ModuleNotFoundError as exc:
+        if exc.name != "assimulo":
+            raise
+        _stub_assimulo_modules(monkeypatch)
+
+        from PharmaPy import Drying_Model
+
+    return Drying_Model
+
+
+def test_unit_model_uses_relative_permeability_for_gas_velocity(monkeypatch):
+    drying_model = _import_drying_model(monkeypatch)
+    dryer = drying_model.Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer.idx_volatiles = np.array([0, 2])
+    dryer.num_volatiles = 2
+    dryer.s_inf = 0.1  # [-]
+    dryer.porosity = 0.5  # [-]
+    dryer.rho_sol = 5.0  # [kg/m**3]
+    dryer.dPg_dz = 11.0  # [Pa/m]
+    dryer.k_perm = 0.2  # [m**2]
+    dryer.pres_gas = np.array([101325.0, 101300.0])  # [Pa]
+    dryer.CakePhase = SimpleNamespace(alpha=2.0)  # [m/kg]
+    dryer.Liquid_1 = SimpleNamespace(
+        num_species=3,
+        rho_liq=np.array([800.0, 850.0, 900.0]),  # [kg/m**3]
+    )
+    dryer.Vapor_1 = SimpleNamespace(
+        mw=np.array([18.0, 28.0, 44.0]),  # [g/mol]
+        getViscosity=lambda temp, mass_frac: np.array([2.0, 4.0]),  # [Pa*s]
+    )
+    dryer.get_drying_rate = lambda *args: np.zeros((2, 3))  # [mol/m**3/s]
+    dryer.get_inputs = lambda time: {
+        "Inlet": {
+            "mass_frac": np.array([0.01, 0.98, 0.01]),  # [-]
+            "temp": 300.0,  # [K]
+        }
+    }
+
+    captured = {}
+
+    def material_balance(
+        time,
+        satur,
+        temp_gas,
+        temp_sol,
+        y_gas,
+        x_liq,
+        u_gas,
+        dens_gas,
+        dry_rate,
+        inputs,
+    ):
+        captured["u_gas"] = u_gas.copy()
+        return [np.zeros(2), np.zeros((2, 3)), np.zeros((2, 2))]
+
+    def energy_balance(
+        time,
+        temp_gas,
+        temp_sol,
+        satur,
+        y_gas,
+        x_liq,
+        u_gas,
+        rho_gas,
+        dry_rate,
+        inputs,
+    ):
+        return [np.zeros(2), np.zeros(2)]
+
+    dryer.material_balance = material_balance
+    dryer.energy_balance = energy_balance
+
+    states = np.array(
+        [
+            [1.0, 0.02, 0.96, 0.02, 0.25, 0.75, 300.0, 299.0],
+            [0.1, 0.02, 0.96, 0.02, 0.25, 0.75, 301.0, 298.0],
+        ]
+    )
+
+    dryer.unit_model(0.0, states.ravel())
+
+    # k_ra is dimensionless. At S=1 it is zero, and at S=s_inf it is one.
+    # k_perm*dP/dz/viscosity: [m**2] * [Pa/m] / [Pa*s] = [m/s].
+    np.testing.assert_allclose(captured["u_gas"], np.array([0.0, 0.55]))
+
+
+def test_material_balance_uses_single_gas_holdup_factor_for_transfer(monkeypatch):
+    drying_model = _import_drying_model(monkeypatch)
+    dryer = drying_model.Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer.idx_volatiles = np.array([0, 2])
+    dryer.porosity = 0.5  # [-]
+    dryer.rho_liq = np.array([800.0, 900.0])  # [kg/m**3]
+    dryer.dz = np.ones(2)  # [m]
+    dryer.Liquid_1 = SimpleNamespace(mw=np.array([18.0, 28.0, 46.0]))  # [g/mol]
+
+    satur = np.array([0.75, 0.25])  # [-]
+    temp_gas = np.array([300.0, 305.0])  # [K]
+    temp_sol = np.array([299.0, 304.0])  # [K]
+    y_gas = np.zeros((2, 3))  # [-], keeps the saturation correction out
+    x_liq = np.array([[0.25, 0.75], [0.40, 0.60]])  # [-]
+    u_gas = np.zeros(2)  # [m/s], isolates the transfer term
+    dens_gas = np.array([2.0, 4.0])  # [kg/m**3]
+    dry_rate = np.array(
+        [
+            [0.2, 0.0, 0.0],
+            [0.4, 0.0, 0.0],
+        ]
+    )  # current material_balance dry_rate basis
+    inputs = {"mass_frac": np.zeros(3)}
+
+    _, dygas_dt, _ = dryer.material_balance(
+        time=0.0,
+        satur=satur,
+        temp_gas=temp_gas,
+        temp_sol=temp_sol,
+        y_gas=y_gas,
+        x_liq=x_liq,
+        u_gas=u_gas,
+        dens_gas=dens_gas,
+        dry_rate=dry_rate,
+        inputs=inputs,
+    )
+
+    expected = np.array(
+        [
+            [0.8, 0.0, 0.0],
+            [0.26666666666666666, 0.0, 0.0],
+        ]
+    )
+    np.testing.assert_allclose(dygas_dt, expected)
+
+
+def test_solve_unit_single_node_initial_state_includes_condensed_temperature(
+    monkeypatch,
+):
+    drying_model = _import_drying_model(monkeypatch)
+    monkeypatch.setattr(drying_model, "get_sat_inf", lambda *args: 0.2)
+
+    dryer = drying_model.Drying(number_nodes=1, supercrit_names=["nitrogen"])
+    dryer.names_states_in = ["temp", "mass_frac"]
+    dryer.idx_supercrit = np.array([1])
+    dryer.cake_height = 1.0  # [m]
+    dryer.Liquid_1 = SimpleNamespace(
+        num_species=3,
+        mass_frac=np.array([0.20, 0.10, 0.70]),  # [-]
+        mw=np.array([18.0, 28.0, 46.0]),  # [g/mol]
+        getDensity=lambda temp, mass_frac, basis: np.array([900.0]),  # [kg/m**3]
+        getSurfTension=lambda temp, mass_frac: np.array([0.072]),  # [N/m]
+    )
+    solid = SimpleNamespace(
+        temp=302.0,  # [K]
+        x_distrib=np.array([1.0, 2.0]),  # [m]
+        distrib=np.array([1.0, 1.0]),  # [-]
+        moments=np.array([1.0, 1.0, 2.0, 4.0, 0.0]),
+        getDensity=lambda: 1200.0,  # [kg/m**3]
+        getCp=lambda: 700.0,  # [J/kg/K]
+        getMoments=lambda mom_num: np.array([1.0, 1.0, 2.0, 4.0, 0.0]),
+    )
+    dryer.Solid_1 = solid
+    dryer.Vapor_1 = SimpleNamespace(
+        mass_frac=np.array([0.01, 0.98, 0.01]),  # [-]
+        temp=300.0,  # [K]
+    )
+    dryer.CakePhase = SimpleNamespace(
+        Liquid_1=SimpleNamespace(mass_frac=np.array([0.20, 0.10, 0.70])),
+        Solid_1=solid,
+        saturation=np.array([0.55]),  # [-]
+        z_external=np.array([0.0, 1.0]),  # [m]
+        alpha=2.0,  # [m/kg]
+        porosity=0.45,  # [-]
+    )
+
+    class CapturedInitialState(Exception):
+        pass
+
+    def assert_initial_state_width(time, states, sw=None):
+        expected_width = 3 + dryer.Liquid_1.num_species + 2
+        assert states.size == dryer.num_nodes * expected_width
+        raise CapturedInitialState
+
+    dryer.unit_model = assert_initial_state_width
+
+    with pytest.raises(CapturedInitialState):
+        dryer.solve_unit(deltaP=10.0)

--- a/tests/test_drying_gas_balance.py
+++ b/tests/test_drying_gas_balance.py
@@ -77,6 +77,7 @@ def _import_drying_model(monkeypatch):
 
 
 def test_unit_model_uses_relative_permeability_for_gas_velocity(monkeypatch):
+    """Darcy velocity uses the clipped relative permeability factor [-]."""
     drying_model = _import_drying_model(monkeypatch)
     dryer = drying_model.Drying(number_nodes=3, supercrit_names=["nitrogen"])
     dryer.idx_volatiles = np.array([0, 2])  # component indices [-]
@@ -152,7 +153,7 @@ def test_unit_model_uses_relative_permeability_for_gas_velocity(monkeypatch):
             [0.1, 0.02, 0.96, 0.02, 0.25, 0.75, 301.0, 298.0],
             [1.2, 0.02, 0.96, 0.02, 0.25, 0.75, 302.0, 297.0],
         ]
-    )
+    )  # columns: saturation [-], y_gas [-], x_liq [-], temp_gas/temp_cond [K]
 
     dryer.unit_model(0.0, states.ravel())
 
@@ -162,6 +163,7 @@ def test_unit_model_uses_relative_permeability_for_gas_velocity(monkeypatch):
 
 
 def test_material_balance_uses_single_gas_holdup_factor_for_transfer(monkeypatch):
+    """Gas transfer divides by the gas holdup exactly once."""
     drying_model = _import_drying_model(monkeypatch)
     dryer = drying_model.Drying(number_nodes=3, supercrit_names=["nitrogen"])
     dryer.idx_volatiles = np.array([0, 2])  # component indices [-]
@@ -228,7 +230,7 @@ def test_solve_unit_single_node_initial_state_includes_condensed_temperature(
 
     dryer = drying_model.Drying(number_nodes=1, supercrit_names=["nitrogen"])
     dryer.names_states_in = ["temp", "mass_frac"]
-    dryer.idx_supercrit = np.array([1])
+    dryer.idx_supercrit = np.array([1])  # component indices [-]
     dryer.cake_height = 1.0  # [m]
     dryer.Liquid_1 = SimpleNamespace(
         num_species=3,
@@ -253,7 +255,7 @@ def test_solve_unit_single_node_initial_state_includes_condensed_temperature(
         temp=300.0,  # [K]
     )
     dryer.CakePhase = SimpleNamespace(
-        Liquid_1=SimpleNamespace(mass_frac=np.array([0.20, 0.10, 0.70])),
+        Liquid_1=SimpleNamespace(mass_frac=np.array([0.20, 0.10, 0.70])),  # [-]
         Solid_1=solid,
         saturation=np.array([0.55]),  # [-]
         z_external=np.array([0.0, 1.0]),  # [m]

--- a/tests/test_drying_gas_balance.py
+++ b/tests/test_drying_gas_balance.py
@@ -22,9 +22,13 @@ def _stub_assimulo_modules(monkeypatch):
     problem = ModuleType("assimulo.problem")
     problem.Explicit_Problem = ExplicitProblem
 
+    exception = ModuleType("assimulo.exception")
+    exception.TerminateSimulation = Exception
+
     monkeypatch.setitem(sys.modules, "assimulo", assimulo)
     monkeypatch.setitem(sys.modules, "assimulo.solvers", solvers)
     monkeypatch.setitem(sys.modules, "assimulo.problem", problem)
+    monkeypatch.setitem(sys.modules, "assimulo.exception", exception)
 
 
 def _import_drying_model(monkeypatch):

--- a/tests/test_drying_gas_balance.py
+++ b/tests/test_drying_gas_balance.py
@@ -17,6 +17,18 @@ pytestmark = pytest.mark.unit
 
 
 def _stub_assimulo_modules(monkeypatch):
+    """Provide the minimal optional Assimulo API needed to import Drying.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Pytest cleanup fixture used only to register temporary import modules.
+
+    Notes
+    -----
+    The stub is limited to import-time solver symbols. These tests do not
+    replace the drying calculations under review with solver behavior.
+    """
     assimulo = ModuleType("assimulo")
 
     class ExplicitProblem:
@@ -40,6 +52,18 @@ def _stub_assimulo_modules(monkeypatch):
 
 
 def _import_drying_model(monkeypatch):
+    """Import ``PharmaPy.Drying_Model`` for solver-free unit tests.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Used only when the optional Assimulo package is absent locally.
+
+    Returns
+    -------
+    module
+        Imported ``PharmaPy.Drying_Model`` module.
+    """
     try:
         from PharmaPy import Drying_Model
     except ModuleNotFoundError as exc:
@@ -192,8 +216,15 @@ def test_material_balance_uses_single_gas_holdup_factor_for_transfer(monkeypatch
 def test_solve_unit_single_node_initial_state_includes_condensed_temperature(
     monkeypatch,
 ):
+    """Pin single-node state assembly before the CVode solve boundary.
+
+    The test uses real ``solve_unit`` initialization, including the
+    ``get_sat_inf`` saturation calculation. It replaces ``unit_model`` only at
+    the final handoff so the initial state can be inspected without running a
+    full transient; the broader end-to-end Drying solve remains deferred until
+    the open Drying correctness issues are resolved.
+    """
     drying_model = _import_drying_model(monkeypatch)
-    monkeypatch.setattr(drying_model, "get_sat_inf", lambda *args: 0.2)
 
     dryer = drying_model.Drying(number_nodes=1, supercrit_names=["nitrogen"])
     dryer.names_states_in = ["temp", "mass_frac"]
@@ -210,6 +241,7 @@ def test_solve_unit_single_node_initial_state_includes_condensed_temperature(
         temp=302.0,  # [K]
         x_distrib=np.array([1.0, 2.0]),  # [m]
         distrib=np.array([1.0, 1.0]),  # [-]
+        # Synthetic distribution moments [m**0, m, m**2, m**3, m**4].
         moments=np.array([1.0, 1.0, 2.0, 4.0, 0.0]),
         getDensity=lambda: 1200.0,  # [kg/m**3]
         getCp=lambda: 700.0,  # [J/kg/K]

--- a/tests/test_drying_gas_balance.py
+++ b/tests/test_drying_gas_balance.py
@@ -1,3 +1,11 @@
+"""Focused Drying gas-balance regressions for issue #81.
+
+These tests use compact synthetic RHS/state-assembly fixtures rather than a
+full ``Drying.solve_unit`` transient. The end-to-end transient remains deferred
+until the open Drying correctness issues are resolved, so the assertions here
+pin the local unit and holdup contracts affected by #81.
+"""
+
 import sys
 from types import ModuleType, SimpleNamespace
 

--- a/tests/test_drying_gas_balance.py
+++ b/tests/test_drying_gas_balance.py
@@ -54,7 +54,7 @@ def _import_drying_model(monkeypatch):
 
 def test_unit_model_uses_relative_permeability_for_gas_velocity(monkeypatch):
     drying_model = _import_drying_model(monkeypatch)
-    dryer = drying_model.Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer = drying_model.Drying(number_nodes=3, supercrit_names=["nitrogen"])
     dryer.idx_volatiles = np.array([0, 2])
     dryer.num_volatiles = 2
     dryer.s_inf = 0.1  # [-]
@@ -62,7 +62,7 @@ def test_unit_model_uses_relative_permeability_for_gas_velocity(monkeypatch):
     dryer.rho_sol = 5.0  # [kg/m**3]
     dryer.dPg_dz = 11.0  # [Pa/m]
     dryer.k_perm = 0.2  # [m**2]
-    dryer.pres_gas = np.array([101325.0, 101300.0])  # [Pa]
+    dryer.pres_gas = np.array([101325.0, 101300.0, 101275.0])  # [Pa]
     dryer.CakePhase = SimpleNamespace(alpha=2.0)  # [m/kg]
     dryer.Liquid_1 = SimpleNamespace(
         num_species=3,
@@ -70,9 +70,9 @@ def test_unit_model_uses_relative_permeability_for_gas_velocity(monkeypatch):
     )
     dryer.Vapor_1 = SimpleNamespace(
         mw=np.array([18.0, 28.0, 44.0]),  # [g/mol]
-        getViscosity=lambda temp, mass_frac: np.array([2.0, 4.0]),  # [Pa*s]
+        getViscosity=lambda temp, mass_frac: np.array([2.0, 4.0, 5.0]),  # [Pa*s]
     )
-    dryer.get_drying_rate = lambda *args: np.zeros((2, 3))  # [mol/m**3/s]
+    dryer.get_drying_rate = lambda *args: np.zeros((3, 3))  # [mol/m**3/s]
     dryer.get_inputs = lambda time: {
         "Inlet": {
             "mass_frac": np.array([0.01, 0.98, 0.01]),  # [-]
@@ -95,7 +95,7 @@ def test_unit_model_uses_relative_permeability_for_gas_velocity(monkeypatch):
         inputs,
     ):
         captured["u_gas"] = u_gas.copy()
-        return [np.zeros(2), np.zeros((2, 3)), np.zeros((2, 2))]
+        return [np.zeros(3), np.zeros((3, 3)), np.zeros((3, 2))]
 
     def energy_balance(
         time,
@@ -109,7 +109,7 @@ def test_unit_model_uses_relative_permeability_for_gas_velocity(monkeypatch):
         dry_rate,
         inputs,
     ):
-        return [np.zeros(2), np.zeros(2)]
+        return [np.zeros(3), np.zeros(3)]
 
     dryer.material_balance = material_balance
     dryer.energy_balance = energy_balance
@@ -118,36 +118,42 @@ def test_unit_model_uses_relative_permeability_for_gas_velocity(monkeypatch):
         [
             [1.0, 0.02, 0.96, 0.02, 0.25, 0.75, 300.0, 299.0],
             [0.1, 0.02, 0.96, 0.02, 0.25, 0.75, 301.0, 298.0],
+            [1.2, 0.02, 0.96, 0.02, 0.25, 0.75, 302.0, 297.0],
         ]
     )
 
     dryer.unit_model(0.0, states.ravel())
 
-    # k_ra is dimensionless. At S=1 it is zero, and at S=s_inf it is one.
+    # k_ra is dimensionless. At S=1 and above it is zero; at S=s_inf it is one.
     # k_perm*dP/dz/viscosity: [m**2] * [Pa/m] / [Pa*s] = [m/s].
-    np.testing.assert_allclose(captured["u_gas"], np.array([0.0, 0.55]))
+    np.testing.assert_allclose(captured["u_gas"], np.array([0.0, 0.55, 0.0]))
 
 
 def test_material_balance_uses_single_gas_holdup_factor_for_transfer(monkeypatch):
     drying_model = _import_drying_model(monkeypatch)
-    dryer = drying_model.Drying(number_nodes=2, supercrit_names=["nitrogen"])
+    dryer = drying_model.Drying(number_nodes=3, supercrit_names=["nitrogen"])
     dryer.idx_volatiles = np.array([0, 2])
     dryer.porosity = 0.5  # [-]
-    dryer.rho_liq = np.array([800.0, 900.0])  # [kg/m**3]
-    dryer.dz = np.ones(2)  # [m]
+    dryer.rho_liq = np.array([800.0, 900.0, 1000.0])  # [kg/m**3]
+    dryer.dz = np.ones(3)  # [m]
     dryer.Liquid_1 = SimpleNamespace(mw=np.array([18.0, 28.0, 46.0]))  # [g/mol]
 
-    satur = np.array([0.75, 0.25])  # [-]
-    temp_gas = np.array([300.0, 305.0])  # [K]
-    temp_sol = np.array([299.0, 304.0])  # [K]
-    y_gas = np.zeros((2, 3))  # [-], keeps the saturation correction out
-    x_liq = np.array([[0.25, 0.75], [0.40, 0.60]])  # [-]
-    u_gas = np.zeros(2)  # [m/s], isolates the transfer term
-    dens_gas = np.array([2.0, 4.0])  # [kg/m**3]
+    satur = np.array([0.75, 0.25, 0.50])  # [-]
+    temp_gas = np.array([300.0, 305.0, 310.0])  # [K]
+    temp_sol = np.array([299.0, 304.0, 309.0])  # [K]
+    y_gas = np.zeros((3, 3))  # [-], keeps the saturation correction out
+    x_liq = np.array([
+        [0.25, 0.75],
+        [0.40, 0.60],
+        [0.55, 0.45],
+    ])  # [-]
+    u_gas = np.zeros(3)  # [m/s], isolates the transfer term
+    dens_gas = np.array([2.0, 4.0, 5.0])  # [kg/m**3]
     dry_rate = np.array(
         [
             [0.2, 0.0, 0.0],
             [0.4, 0.0, 0.0],
+            [0.6, 0.0, 0.0],
         ]
     )  # current material_balance dry_rate basis
     inputs = {"mass_frac": np.zeros(3)}
@@ -169,6 +175,7 @@ def test_material_balance_uses_single_gas_holdup_factor_for_transfer(monkeypatch
         [
             [0.8, 0.0, 0.0],
             [0.26666666666666666, 0.0, 0.0],
+            [0.48, 0.0, 0.0],
         ]
     )
     np.testing.assert_allclose(dygas_dt, expected)
@@ -220,6 +227,9 @@ def test_solve_unit_single_node_initial_state_includes_condensed_temperature(
     def assert_initial_state_width(time, states, sw=None):
         expected_width = 3 + dryer.Liquid_1.num_species + 2
         assert states.size == dryer.num_nodes * expected_width
+        node = states.reshape(dryer.num_nodes, expected_width)
+        assert node[0, -2] == 300.0  # temp_gas [K]
+        assert node[0, -1] == 302.0  # temp_cond [K]
         raise CapturedInitialState
 
     dryer.unit_model = assert_initial_state_width

--- a/tests/test_drying_model.py
+++ b/tests/test_drying_model.py
@@ -183,6 +183,9 @@ def test_material_balance_uses_mass_drying_rate_for_gas_species():
         inputs=inputs,
     )  # [1/s]
 
+    # This expectation updates the earlier mass-basis regression after #81
+    # removed the duplicate gas-holdup divisor: ``epsilon_gas`` already
+    # contains ``porosity * (1 - satur)`` [-].
     expected_dygas_dt = np.array([
         [0.119912, -0.000704, 0.6132453333333334],
         [0.1437728, -0.0007952, 0.6132197333333333],

--- a/tests/test_drying_model.py
+++ b/tests/test_drying_model.py
@@ -145,6 +145,18 @@ def test_unit_model_converts_drying_rate_before_balance_equations(monkeypatch):
 
 
 def test_material_balance_uses_mass_drying_rate_for_gas_species():
+    """Verify gas-species transfer after the #81 gas-holdup correction.
+
+    Notes
+    -----
+    This regression was added by the earlier molar-to-mass drying-rate fix.
+    That mass-basis contract is still unchanged: ``dry_rate`` enters this
+    helper as [kg/m**3/s]. The expected gas-species values changed in #81
+    because this branch also asserted the old duplicate gas-holdup divisor.
+    With ``satur = 0.5`` [-], that extra ``(1 - satur)`` [-] divisor doubled
+    the drying-transfer contribution. The explicit pieces below separate that
+    corrected transfer term from the unchanged saturation-correction term.
+    """
     dryer = Drying(number_nodes=2, supercrit_names=["nitrogen"])
     dryer.idx_volatiles = np.array([0, 2])  # [-]
     dryer.porosity = 0.5  # [-]
@@ -183,12 +195,18 @@ def test_material_balance_uses_mass_drying_rate_for_gas_species():
         inputs=inputs,
     )  # [1/s]
 
-    # This expectation updates the earlier mass-basis regression after #81
-    # removed the duplicate gas-holdup divisor: ``epsilon_gas`` already
-    # contains ``porosity * (1 - satur)`` [-].
-    expected_dygas_dt = np.array([
+    expected_transfer = np.array([
+        [0.12, 0.0, 0.6133333333333334],
+        [0.144, 0.0, 0.6133333333333333],
+    ])  # [1/s]
+    expected_saturation_correction = np.array([
+        [-0.000088, -0.000704, -0.000088],
+        [-0.0002272, -0.0007952, -0.0001136],
+    ])  # [1/s]
+    expected_dygas_dt = expected_transfer + expected_saturation_correction  # [1/s]
+    np.testing.assert_allclose(expected_dygas_dt, np.array([
         [0.119912, -0.000704, 0.6132453333333334],
         [0.1437728, -0.0007952, 0.6132197333333333],
-    ])  # [1/s]
+    ]))  # [1/s]
 
     np.testing.assert_allclose(dygas_dt, expected_dygas_dt)

--- a/tests/test_plotting_unit_labels.py
+++ b/tests/test_plotting_unit_labels.py
@@ -1,0 +1,35 @@
+"""Regression tests for plotting unit metadata labels."""
+
+import matplotlib.pyplot as plt
+
+from PharmaPy.Plotting import format_unit_label, latexify_name, name_yaxes
+
+
+def test_format_unit_label_accepts_bracketed_metadata():
+    """Bracketed source metadata renders without nested brackets."""
+    temp_units = "[K]"
+    density_units = "[kg/m**3]"
+
+    assert format_unit_label(temp_units) == latexify_name(temp_units[1:-1], units=True)
+    assert format_unit_label(density_units) == latexify_name(
+        density_units[1:-1], units=True)
+
+
+def test_name_yaxes_suppresses_dimensionless_metadata():
+    """Dimensionless ``[-]`` metadata does not add a plot-label suffix."""
+    temp_units = "[K]"
+    fig, axes = plt.subplots(1, 2)
+    states = {
+        "temp": {"units": temp_units},
+        "x_liq": {"units": "[-]"},
+    }
+
+    try:
+        name_yaxes(axes, states, ("temp", "x_liq"), ("T", "x_liq"), True)
+
+        assert axes[0].get_ylabel() == (
+            f"{latexify_name('T')} ({latexify_name(temp_units[1:-1], units=True)})"
+        )
+        assert axes[1].get_ylabel() == latexify_name("x_liq")
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
## Summary

- Restore the drying gas Darcy velocity to the relative-permeability form so gas flow goes to zero at full saturation and remains finite near irreducible saturation.
- Remove the extra `(1 - satur)` divisor from the gas species evaporation source; `epsilon_gas` already carries the gas holdup.
- Include `temp_cond_init` in the uniform single-node `solve_unit` initial state vector so the state width matches `unit_model`.
- Add focused unit regressions for all three issue #81 defects without promoting a brittle full `solve_unit` transient.
- Document the affected RHS, material-balance, initialization, and regression-test unit/state contracts in source.

Closes #81.
Refs #7, #21, #24, #28, #37, #42, #48, #101, #108, #116.

## Acceptance Criteria

- [x] Gas velocity uses `k_perm * k_ra * dPg_dz / visc_gas`.
- [x] Gas velocity is zero at `S = 1` and finite at `S = s_inf`.
- [x] Gas species transfer uses one gas-holdup factor, `epsilon_gas = porosity * (1 - satur)`, not `porosity * (1 - satur)^2`.
- [x] Uniform single-node initialization includes `temp_cond` in the initial state vector.
- [x] Regression tests fail against unchanged `origin/master` and pass with this patch.

## Dimensional Analysis

- Darcy gas velocity: `k_perm [m**2] * dPg_dz [Pa/m] / visc_gas [Pa*s] = m/s`; `k_ra` is dimensionless.
- Gas holdup: `epsilon_gas = porosity * (1 - satur)` is dimensionless and already represents the gas-filled void fraction.
- Gas source denominator: `epsilon_gas * dens_gas` is the gas accumulation coefficient. Dividing again by `(1 - satur)` incorrectly changes the holdup scaling.
- Single-node state width: `S | y_gas | x_liq | Tg | Tcond`, so width is `3 + num_comp + num_volatiles`.

## Coordination Notes

- PR #108 is the only open PR currently touching `PharmaPy/Drying_Model.py`; it addresses #21's drying-rate molar-to-mass basis. This PR is based on `master` rather than stacked on #108, and intentionally limits the gas source change to removing the duplicate holdup factor so it does not duplicate #21's basis conversion work.
- PR #116 was the focused #48 energy-rate regression and is now merged. Its end-to-end Drying discussion still applies: a full class/Purdue-style `solve_unit` transient should wait until the open Drying correctness issues are solved and merged, otherwise the test would assert unstable or physically misleading behavior.
- Broader end-to-end Drying integration coverage should be coordinated through #7 or a dedicated follow-up after the drying correctness cluster is closed.

## Tests

- Red check on unchanged `origin/master` (`0f89b71999daf9b765ff80255a61ed73e9e9f0e5`): `conda run -n pharmapy python -m pytest tests/test_drying_gas_balance.py -q` failed with 3 expected failures.
- `conda run -n pharmapy python -m pytest tests/test_drying_gas_balance.py -q` - 3 passed.
- `conda run -n pharmapy python -m pytest tests/test_drying_model.py tests/test_drying_gas_balance.py -q` - 4 passed.
- `conda run -n pharmapy python -m pytest tests/ -m "not assimulo" -q` - 43 passed, 10 deselected.
- `conda run -n pharmapy python -m pytest tests/ -m assimulo -q` - 10 passed, 43 deselected.
- `git diff --cached --check` - passed before commit.

## Branch Hygiene

- Base branch: `master`.
- Source branch point: `origin/master` at `0f89b71999daf9b765ff80255a61ed73e9e9f0e5`.
- Stacked status: not stacked.
- Same-file overlap: PR #108 also edits `PharmaPy/Drying_Model.py`; no test-file overlap because this PR adds `tests/test_drying_gas_balance.py`.
- Final branch diff now covers `PharmaPy/Drying_Model.py`, `PharmaPy/Plotting.py`, `tests/test_drying_gas_balance.py`, and `tests/test_plotting_unit_labels.py`.

<!-- gh-arc:metadata=start -->
## Review Follow-Up Metadata

<!-- gh-arc:metadata=review-audit-follow-up:sha=ef304822173a3153084bdbd2a0b37e76893cacef -->

- Pushed `ef30482` directly to existing branch `fix/issue-81-drying-gas-balance`.
- Addressed Bernalde's follow-up that the earlier inline reply did not answer why an earlier test's expected computation changed. `tests/test_drying_model.py::test_material_balance_uses_mass_drying_rate_for_gas_species` now explains that the earlier regression was introduced for the molar-to-mass drying-rate contract, which remains unchanged at [kg/m**3/s].
- The test now separates the corrected gas-transfer contribution [1/s] from the unchanged saturation-correction contribution [1/s]. This documents that #81 changed only the gas-species transfer denominator by removing the old duplicate gas-holdup divisor; with `satur = 0.5` [-], that previous extra `(1 - satur)` [-] divisor doubled the transfer contribution.
- No production behavior changed in `ef30482`; this commit is test documentation and expected-value decomposition only.
- Prior in-scope audit items remain addressed: touched drying docs/units use NumPy-style documentation and bracketed units, #28/#37/#42 computation debt remains documented as out of scope, and bracketed `states_di` metadata is kept with plot-label rendering handled by `Plotting.format_unit_label`.
- Verification: unit audit passed; focused tests `9 passed, 1 warning`; full suite `59 passed, 2 warnings`; diff check passed.
<!-- gh-arc:metadata=end -->
