### PR TITLE
Fix DynamicExtractor default equilibrium function

### DIFF
--- a/PharmaPy/DynamicExtraction.py
+++ b/PharmaPy/DynamicExtraction.py
@@ -46,6 +46,22 @@ def complete_molefrac(mole_frac, mapping):
 
 class DynamicExtractor:
     def __init__(self, num_stages, k_fun=None, eff=1, gamma_model='UNIQUAC'):
+        """Create a staged dynamic extractor.
+
+        Parameters
+        ----------
+        num_stages : int
+            Number of extractor stages [-].
+        k_fun : callable, optional
+            Equilibrium function. It must accept light-phase mole fractions
+            ``x_light`` [-], heavy-phase mole fractions ``x_heavy`` [-], and
+            temperature ``temp`` [K], and return distribution coefficients
+            ``K_i = gamma_light/gamma_heavy`` [-].
+        eff : float, optional
+            Stage efficiency [-].
+        gamma_model : {'ideal', 'UNIFAC', 'UNIQUAC'}, optional
+            Activity-coefficient method used by the default ``k_fun``.
+        """
 
         self.num_stages = num_stages
 
@@ -73,14 +89,19 @@ class DynamicExtractor:
         self.default_output = 'feed'
 
     def _default_k_fun(self, x_light, x_heavy, temp):
-        """Return liquid-liquid distribution coefficients ``K_i`` [-]."""
+        """Return liquid-liquid distribution coefficients ``K_i`` [-].
+
+        ``x_light`` and ``x_heavy`` are liquid mole fractions [-], and
+        ``temp`` is temperature [K]. Activity coefficients are dimensionless,
+        so their ratio is the dimensionless extraction equilibrium constant.
+        """
         gamma_light = self.Liquid_1.getActivityCoeff(
-            method=self.gamma_model, mole_frac=x_light, temp=temp)
+            method=self.gamma_model, mole_frac=x_light, temp=temp)  # [-]
 
         gamma_heavy = self.Liquid_1.getActivityCoeff(
-            method=self.gamma_model, mole_frac=x_heavy, temp=temp)
+            method=self.gamma_model, mole_frac=x_heavy, temp=temp)  # [-]
 
-        return gamma_light / gamma_heavy
+        return gamma_light / gamma_heavy  # K_i [-]
 
     def nomenclature(self):
         num_comp = self.num_comp
@@ -265,8 +286,8 @@ class DynamicExtractor:
         # print(x_augm.sum(axis=1))
 
         # ---------- Equilibrium
-        k_ij = self.k_fun(x_i, y_i, temp)  # TODO: make this stage-wise
-        m_ij = k_ij / self.eff
+        k_ij = self.k_fun(x_i, y_i, temp)  # K_i [-]; TODO: stage-wise
+        m_ij = k_ij / self.eff  # [-]
 
         # ---------- Differential block
         dxij_dt = y_augm[1:] * heavy_flows[1:, np.newaxis] \
@@ -437,9 +458,9 @@ class DynamicExtractor:
 
             x_eqns = (HR * xi + HE * yi - mol_i) / HR
 
-            k_ij = self.k_fun(xi, yi, temp)
+            k_ij = self.k_fun(xi, yi, temp)  # K_i [-]
 
-            m_ij = k_ij / self.eff  # TODO: it's not calculated stage-wise (yet)
+            m_ij = k_ij / self.eff  # [-]; TODO: stage-wise
 
             y_eqns = np.zeros_like(yi)
             y_eqns[0] = m_ij * xi[0] - yi[0]

--- a/PharmaPy/DynamicExtraction.py
+++ b/PharmaPy/DynamicExtraction.py
@@ -9,7 +9,7 @@ from PharmaPy.Commons import unpack_discretized, retrieve_pde_result, flatten_st
 from PharmaPy.Results import DynamicResult
 from PharmaPy.Streams import LiquidStream
 
-from PharmaPy.Extractors import BatchExtractor
+from PharmaPy.Extractors import BatchExtractor, validate_gamma_method
 from PharmaPy.Plotting import plot_distrib
 
 from assimulo.solvers import IDA
@@ -65,6 +65,7 @@ class DynamicExtractor:
 
         self.num_stages = num_stages
 
+        validate_gamma_method(gamma_model, param_name='gamma_model')
         self.gamma_model = gamma_model
         if callable(k_fun):
             self.k_fun = k_fun

--- a/PharmaPy/DynamicExtraction.py
+++ b/PharmaPy/DynamicExtraction.py
@@ -49,10 +49,11 @@ class DynamicExtractor:
 
         self.num_stages = num_stages
 
+        self.gamma_model = gamma_model
         if callable(k_fun):
             self.k_fun = k_fun
         else:
-            pass  # Use UNIFAC/UNIQUAC
+            self.k_fun = self._default_k_fun
 
         self._Phases = None
         self._Inlet = None
@@ -70,6 +71,16 @@ class DynamicExtractor:
         self.oper_mode = 'Continuous'
         self.is_continuous = True
         self.default_output = 'feed'
+
+    def _default_k_fun(self, x_light, x_heavy, temp):
+        """Return liquid-liquid distribution coefficients ``K_i`` [-]."""
+        gamma_light = self.Liquid_1.getActivityCoeff(
+            method=self.gamma_model, mole_frac=x_light, temp=temp)
+
+        gamma_heavy = self.Liquid_1.getActivityCoeff(
+            method=self.gamma_model, mole_frac=x_heavy, temp=temp)
+
+        return gamma_light / gamma_heavy
 
     def nomenclature(self):
         num_comp = self.num_comp
@@ -600,4 +611,3 @@ class DynamicExtractor:
         fig.tight_layout()
 
         return fig, axis
-

--- a/PharmaPy/DynamicExtraction.py
+++ b/PharmaPy/DynamicExtraction.py
@@ -112,10 +112,10 @@ class DynamicExtractor:
         dimensionless extraction equilibrium constant.
         """
         gamma_light = self.Liquid_1.getActivityCoeff(
-            method=self.gamma_model, mole_frac=x_light, temp=temp)
+            method=self.gamma_model, mole_frac=x_light, temp=temp)  # [-]
 
         gamma_heavy = self.Liquid_1.getActivityCoeff(
-            method=self.gamma_model, mole_frac=x_heavy, temp=temp)
+            method=self.gamma_model, mole_frac=x_heavy, temp=temp)  # [-]
 
         return gamma_light / gamma_heavy  # K_i [-]
 
@@ -137,22 +137,24 @@ class DynamicExtractor:
         result and plotting helpers; replacing that structure is outside this
         #56 fix.
         """
-        num_comp = self.num_comp
+        num_comp = self.num_comp  # [-]
         name_species = self.name_species
         self.states_di = {
-            'x_i': {'dim': num_comp, 'type': 'alg', 'index': name_species},
-            'y_i': {'dim': num_comp, 'type': 'alg', 'index': name_species},
+            'x_i': {'dim': num_comp, 'type': 'alg', 'index': name_species,
+                    'units': '[-]'},
+            'y_i': {'dim': num_comp, 'type': 'alg', 'index': name_species,
+                    'units': '[-]'},
             'u_int': {'dim': 1, 'type': 'diff', 'units': '[J]'},
             'temp': {'dim': 1, 'type': 'alg', 'units': '[K]'}
             }
 
         self.name_states = list(self.states_di.keys())
-        self.dim_states = [di['dim'] for di in self.states_di.values()]
+        self.dim_states = [di['dim'] for di in self.states_di.values()]  # [-]
 
-        states_in_dict = {'mole_flow': 1, 'temp': 1, 'mole_frac': num_comp}
+        states_in_dict = {'mole_flow': 1, 'temp': 1, 'mole_frac': num_comp}  # [-]
         self.states_in_dict = {'Inlet': states_in_dict}
 
-        self.alg_map = get_alg_map(self.states_di, self.num_stages)
+        self.alg_map = get_alg_map(self.states_di, self.num_stages)  # [-]
 
         self.fstates_di = {}
 
@@ -201,8 +203,22 @@ class DynamicExtractor:
         self._Inlet = self.inlets
 
     def get_stage_dimensions(self, di_states, rhos):
+        """Set the dynamic-stage liquid volume.
+
+        Parameters
+        ----------
+        di_states : dict
+            Stage holdups. ``holdup_heavy`` and ``holdup_light`` are [mol].
+        rhos : sequence of float
+            Heavy- and light-phase molar densities [mol/L].
+
+        Returns
+        -------
+        None
+            The method stores ``self.vol`` [m**3].
+        """
         vol = di_states['holdup_heavy'][0] / rhos[0] + \
-            di_states['holdup_light'][0] / rhos[1]
+            di_states['holdup_light'][0] / rhos[1]  # [L]
 
         self.vol = vol / 1000  # [m**3]
 
@@ -213,32 +229,49 @@ class DynamicExtractor:
         return inputs
 
     def get_augmented_arrays(self, di_states, inputs):  # bottom_flows):
+        """Build inlet-augmented state arrays for stage balances.
+
+        Parameters
+        ----------
+        di_states : dict
+            Current stage states: mole fractions [-], internal energy [J], and
+            temperature [K].
+        inputs : dict
+            Dynamic inlet values. Mole flows are [mol/s], mole fractions are
+            [-], and temperatures are [K].
+
+        Returns
+        -------
+        tuple of ndarray
+            ``x_augm`` and ``y_augm`` [-], ``temp_augm`` [K],
+            ``light_flows`` [mol/s], and ``heavy_flows`` [mol/s].
+        """
         light = self.target_states['light_phase']
         heavy = self.target_states['heavy_phase']
 
-        x_in = inputs[light]['Inlet']['mole_frac']
-        y_in = inputs[heavy]['Inlet']['mole_frac']
+        x_in = inputs[light]['Inlet']['mole_frac']  # [-]
+        y_in = inputs[heavy]['Inlet']['mole_frac']  # [-]
 
-        temp_in = {key: val['Inlet']['temp'] for key, val in inputs.items()}
+        temp_in = {key: val['Inlet']['temp'] for key, val in inputs.items()}  # [K]
 
-        x_augm = np.vstack((x_in, di_states['x_i']))
-        y_augm = np.vstack((di_states['y_i'], y_in))
+        x_augm = np.vstack((x_in, di_states['x_i']))  # [-]
+        y_augm = np.vstack((di_states['y_i'], y_in))  # [-]
         temp_augm = np.hstack((temp_in['feed'], di_states['temp'],
-                               temp_in['solvent']))
+                               temp_in['solvent']))  # [K]
 
-        light_flows = np.zeros(self.num_stages + 1)
-        heavy_flows = np.zeros_like(light_flows)
+        light_flows = np.zeros(self.num_stages + 1)  # [mol/s]
+        heavy_flows = np.zeros_like(light_flows)  # [mol/s]
 
-        heavy_in = inputs[heavy]['Inlet']['mole_flow']
-        light_in = inputs[light]['Inlet']['mole_flow']
+        heavy_in = inputs[heavy]['Inlet']['mole_flow']  # [mol/s]
+        light_in = inputs[light]['Inlet']['mole_flow']  # [mol/s]
 
-        light_flows[0] = light_in
+        light_flows[0] = light_in  # [mol/s]
         # light_flows[1:] = di_states['top_flows']
-        light_flows[1:] = light_in
+        light_flows[1:] = light_in  # [mol/s]
 
-        heavy_flows[-1] = heavy_in
+        heavy_flows[-1] = heavy_in  # [mol/s]
         # heavy_flows[:-1] = bottom_flows
-        heavy_flows[:-1] = heavy_in
+        heavy_flows[:-1] = heavy_in  # [mol/s]
 
         augm_arrays = (x_augm, y_augm, temp_augm, light_flows, heavy_flows)
 
@@ -308,6 +341,31 @@ class DynamicExtractor:
                           holdup_light, holdup_heavy,  # top_flows,
                           u_int, temp,
                           di_sdot, augm_arrays):
+        """Evaluate dynamic extractor material residuals.
+
+        Parameters
+        ----------
+        time : float
+            Current integration time [s].
+        x_i, y_i : ndarray
+            Stage mole fractions in light and heavy phases [-].
+        holdup_light, holdup_heavy : ndarray
+            Stage liquid holdups [mol].
+        u_int : ndarray
+            Stage internal energies [J].
+        temp : ndarray
+            Stage temperatures [K].
+        di_sdot : dict or None
+            Assimulo state derivatives, with mole-fraction rates [1/s].
+        augm_arrays : tuple of ndarray
+            Inlet-augmented mole fractions [-], temperatures [K], and flows
+            [mol/s].
+
+        Returns
+        -------
+        list of ndarray
+            Mole-fraction rates [1/s] and equilibrium residuals [-].
+        """
 
         x_augm, y_augm, temp_augm, light_flows, heavy_flows = augm_arrays
         # Augmented mole fractions [-], temperatures [K], and flows [mol/s].
@@ -343,7 +401,7 @@ class DynamicExtractor:
         if di_sdot is not None:
             dxij_dt = dxij_dt - di_sdot['x_i']  # [1/s]
 
-        out = [dxij_dt, equilibrium_alg]
+        out = [dxij_dt, equilibrium_alg]  # [1/s, -]
 
         return out
 
@@ -351,46 +409,79 @@ class DynamicExtractor:
                         holdup_light, holdup_heavy,  # top_flows,
                         u_int, temp,
                         di_sdot, augm_arrays):
+        """Evaluate dynamic extractor energy residuals.
+
+        Parameters
+        ----------
+        time : float
+            Current integration time [s].
+        x_i, y_i : ndarray
+            Stage mole fractions in light and heavy phases [-].
+        holdup_light, holdup_heavy : ndarray
+            Stage liquid holdups [mol].
+        u_int : ndarray
+            Stage internal energies [J].
+        temp : ndarray
+            Stage temperatures [K].
+        di_sdot : dict or None
+            Assimulo state derivatives. ``u_int`` derivatives are [J/s].
+        augm_arrays : tuple of ndarray
+            Inlet-augmented mole fractions [-], temperatures [K], and flows
+            [mol/s].
+
+        Returns
+        -------
+        list of ndarray
+            Internal-energy rates [J/s] and algebraic energy residuals [J].
+        """
 
         x_augm, y_augm, temp_augm, light_flows, heavy_flows = augm_arrays
 
         h_light = self.Liquid_1.getEnthalpy(mole_frac=x_augm,
                                             temp=temp_augm[:-1],
-                                            basis='mole')
+                                            basis='mole')  # [J/mol]
 
         h_heavy = self.Liquid_1.getEnthalpy(mole_frac=y_augm,
                                             temp=temp_augm[1:],
-                                            basis='mole')
+                                            basis='mole')  # [J/mol]
 
         duint_dt = heavy_flows[1:] * h_heavy[1:] \
             + light_flows[:-1] * h_light[:-1] \
-            - heavy_flows[:-1] * h_heavy[:-1] - light_flows[1:] * h_light[1:]
+            - heavy_flows[:-1] * h_heavy[:-1] - light_flows[1:] * h_light[1:]  # [J/s]
 
         if di_sdot is not None:
-            duint_dt = duint_dt - di_sdot['u_int']
+            duint_dt = duint_dt - di_sdot['u_int']  # [J/s]
 
         temp_eqns = holdup_heavy * h_heavy[:-1] + holdup_light * h_light[1:] \
-            - u_int
+            - u_int  # [J]
 
-        out = [duint_dt, temp_eqns]
+        out = [duint_dt, temp_eqns]  # [J/s, J]
 
         return out
 
     def initialize_model(self):
+        """Create thermodynamically consistent initial dynamic states.
+
+        Returns
+        -------
+        dict
+            Initial light/heavy mole fractions [-], stage internal energy [J],
+            and temperature [K] for each dynamic extraction stage.
+        """
         # ---------- Equilibrium calculations
         extr = BatchExtractor(k_fun=self.k_fun)
         extr.Phases = copy.deepcopy(self.Liquid_1)
 
         extr.solve_unit()
-        res = extr.result
+        res = extr.result  # extraction result state
 
         # ---------- Discriminate heavy and light phases
         rhos_streams = {key: obj.getDensity(basis='mole')
-                        for key, obj in self.Inlet.items()}
+                        for key, obj in self.Inlet.items()}  # [mol/L]
 
-        rhos_holdups = [res.rho_heavy, res.rho_light]
+        rhos_holdups = [res.rho_heavy, res.rho_light]  # [mol/L]
 
-        idx_raff = np.argmin(abs(rhos_holdups - rhos_streams['feed']))
+        idx_raff = np.argmin(abs(rhos_holdups - rhos_streams['feed']))  # [-]
 
         target_states = {'x_light': 'x_i', 'x_heavy': 'y_i'}
                          # 'mol_light': 'holdup_light',
@@ -407,8 +498,8 @@ class DynamicExtractor:
         self.target_states = target_states
 
         # Store fixed values
-        self.fixed_vals['H_R'] = res.mol_light
-        self.fixed_vals['H_E'] = res.mol_heavy
+        self.fixed_vals['H_R'] = res.mol_light  # [mol]
+        self.fixed_vals['H_E'] = res.mol_heavy  # [mol]
 
         # inputs = self.get_inputs(0)
 
@@ -429,16 +520,16 @@ class DynamicExtractor:
                 else:
                     attr = np.ones(self.num_stages) * attr
 
-                di_init[name] = attr
+                di_init[name] = attr  # [-]
 
-        di_init['temp'] = self.Liquid_1.temp * np.ones(self.num_stages)
+        di_init['temp'] = self.Liquid_1.temp * np.ones(self.num_stages)  # [K]
 
         keys_frac = ('y_i', 'x_i')
 
         rhos_holdups = [
             self.Liquid_1.getDensity(mole_frac=di_init[key], basis='mole',
                                      temp=di_init['temp'])
-            for key in keys_frac]
+            for key in keys_frac]  # [mol/L]
 
         # self.get_stage_dimensions(di_init,
         #                           [rhos_holdups[0][0], rhos_holdups[1][0]])
@@ -446,18 +537,18 @@ class DynamicExtractor:
         # Energy balance calculations
         h_light = self.Liquid_1.getEnthalpy(mole_frac=di_init['x_i'],
                                             temp=di_init['temp'],
-                                            basis='mole')
+                                            basis='mole')  # [J/mol]
 
         h_heavy = self.Liquid_1.getEnthalpy(mole_frac=di_init['y_i'],
                                             temp=di_init['temp'],
-                                            basis='mole')
+                                            basis='mole')  # [J/mol]
 
         # u_int = di_init['holdup_light'] * h_light \
         #     + di_init['holdup_heavy'] * h_heavy
 
-        u_int = res.mol_light * h_light + res.mol_heavy * h_heavy
+        u_int = res.mol_light * h_light + res.mol_heavy * h_heavy  # [J]
 
-        di_init['u_int'] = u_int
+        di_init['u_int'] = u_int  # [J]
 
         # ---------- Equilibrium correction for x_i and y_i
         def equilibrium_eqns(fracs, temp, mol_i, holdups):
@@ -488,15 +579,15 @@ class DynamicExtractor:
         holdups = [res.mol_light, res.mol_heavy]  # [mol]
         mol_i = res.mol_light * res.x_light + res.mol_heavy * res.x_heavy  # [mol]
 
-        args_eq = (di_init['temp'], mol_i, holdups)
+        args_eq = (di_init['temp'], mol_i, holdups)  # [K], [mol], [mol]
         x0 = np.column_stack((di_init['x_i'], di_init['y_i'])).ravel()  # [-]
 
-        optimopts = {'xtol': 2**(-52)}
+        optimopts = {'xtol': 2**(-52)}  # [-]
         frac_result = root(equilibrium_eqns, x0, args=args_eq)
 
         frac_noneq = frac_result.x  # mole fractions [-]
 
-        frac_noneq = frac_noneq.reshape(self.num_stages, -1)
+        frac_noneq = frac_noneq.reshape(self.num_stages, -1)  # [-]
 
         x_noneq, y_noneq = np.split(frac_noneq, 2, axis=1)  # [-]
 

--- a/PharmaPy/DynamicExtraction.py
+++ b/PharmaPy/DynamicExtraction.py
@@ -21,6 +21,20 @@ from matplotlib.ticker import MaxNLocator, AutoMinorLocator
 
 
 def get_alg_map(states_di, nstages=1):
+    """Build Assimulo algebraic/differential state flags.
+
+    Parameters
+    ----------
+    states_di : dict
+        State metadata dictionaries containing ``dim`` [-] and ``type``.
+    nstages : int, optional
+        Number of dynamic extractor stages [-].
+
+    Returns
+    -------
+    ndarray
+        Algebraic-variable map with one flag per state entry [-].
+    """
     maps = []
     for val in states_di.values():
         if val['type'] == 'diff':
@@ -32,6 +46,20 @@ def get_alg_map(states_di, nstages=1):
 
 
 def complete_molefrac(mole_frac, mapping):
+    """Insert the dependent mole fraction into a reduced composition vector.
+
+    Parameters
+    ----------
+    mole_frac : ndarray
+        Independent mole fractions [-].
+    mapping : ndarray of bool
+        Boolean mask marking independent components [-].
+
+    Returns
+    -------
+    ndarray
+        Complete mole-fraction vector or matrix [-].
+    """
     if mole_frac.ndim == 1:
         out = np.zeros(len(mole_frac) + 1)
         out[mapping] = mole_frac
@@ -278,6 +306,26 @@ class DynamicExtractor:
         return augm_arrays
 
     def unit_model(self, time, states, sdot=None):
+        """Evaluate dynamic extractor DAE residuals.
+
+        Parameters
+        ----------
+        time : float
+            Current integration time [s].
+        states : ndarray
+            Flattened staged states. Mole fractions are [-], internal energy is
+            [J], and temperature is [K].
+        sdot : ndarray, optional
+            Flattened staged state derivatives. Mole-fraction derivatives are
+            [1/s] and internal-energy derivatives are [J/s].
+
+        Returns
+        -------
+        ndarray
+            Flattened material and energy residuals. Entries combine
+            mole-fraction rates [1/s], equilibrium residuals [-],
+            internal-energy rates [J/s], and energy residuals [J].
+        """
 
         # ---------- Unpack variables
         di_states = unpack_discretized(states,
@@ -289,32 +337,12 @@ class DynamicExtractor:
             di_sdot = unpack_discretized(sdot, self.dim_states,
                                          self.name_states)
 
-            # print('\ntime: ', time, end='\n')
-            # fields = ('holdup_light', 'holdup_heavy')
-            # di_print = {key: di_states[key] for key in fields}
-
-            # print(di_print)
-
-            # fields = ('mol_i', )
-            # di_print = {key: {'max': di_sdot[key].max(),
-            #                   'comp': self.name_species[np.argmax(di_sdot[key])]} for key in fields}
-
-            # print(di_print)
-
         inputs = self.get_inputs(time)
 
-        # # Physical properties
-        # rhos = [
-        #     self.Liquid_1.getDensity(mole_frac=di_states['x_i'], basis='mole',
-        #                              temp=di_states['temp']),
-        #     self.Liquid_1.getDensity(mole_frac=di_states['y_i'], basis='mole',
-        #                              temp=di_states['temp'])]
-
         augm_arrays = self.get_augmented_arrays(di_states, inputs)
-                                                # bottom_flows)
 
-        holdup_light = np.ones_like(di_states['temp']) * self.fixed_vals['H_R']
-        holdup_heavy = np.ones_like(di_states['temp']) * self.fixed_vals['H_E']
+        holdup_light = np.ones_like(di_states['temp']) * self.fixed_vals['H_R']  # [mol]
+        holdup_heavy = np.ones_like(di_states['temp']) * self.fixed_vals['H_E']  # [mol]
 
         # ---------- Balances
         material = self.material_balances(time,
@@ -467,9 +495,17 @@ class DynamicExtractor:
         dict
             Initial light/heavy mole fractions [-], stage internal energy [J],
             and temperature [K] for each dynamic extraction stage.
+
+        Notes
+        -----
+        The nested ``BatchExtractor`` receives both the selected ``k_fun`` and
+        ``gamma_model``. The full staged solve still depends on broader
+        stage-wise ``K_i`` support tracked in #123; the handoff itself is
+        covered here without replacing the real thermodynamic callbacks.
         """
         # ---------- Equilibrium calculations
-        extr = BatchExtractor(k_fun=self.k_fun)
+        extr = BatchExtractor(k_fun=self.k_fun,
+                              gamma_method=self.gamma_model)
         extr.Phases = copy.deepcopy(self.Liquid_1)
 
         extr.solve_unit()
@@ -484,8 +520,6 @@ class DynamicExtractor:
         idx_raff = np.argmin(abs(rhos_holdups - rhos_streams['feed']))  # [-]
 
         target_states = {'x_light': 'x_i', 'x_heavy': 'y_i'}
-                         # 'mol_light': 'holdup_light',
-                         # 'mol_heavy': 'holdup_heavy'}
 
         if idx_raff == 0:
             target_states['light_phase'] = 'solvent'
@@ -500,11 +534,6 @@ class DynamicExtractor:
         # Store fixed values
         self.fixed_vals['H_R'] = res.mol_light  # [mol]
         self.fixed_vals['H_E'] = res.mol_heavy  # [mol]
-
-        # inputs = self.get_inputs(0)
-
-        # # self.fixed_vals['R_i'] = inputs[target_states['light_phase']]['Inlet']['mole_flow']
-        # # self.fixed_vals['E_i'] = inputs[target_states['heavy_phase']]['Inlet']['mole_flow']
 
         # ---------- Create dictionary of initial values
         di_init = {}
@@ -531,9 +560,6 @@ class DynamicExtractor:
                                      temp=di_init['temp'])
             for key in keys_frac]  # [mol/L]
 
-        # self.get_stage_dimensions(di_init,
-        #                           [rhos_holdups[0][0], rhos_holdups[1][0]])
-
         # Energy balance calculations
         h_light = self.Liquid_1.getEnthalpy(mole_frac=di_init['x_i'],
                                             temp=di_init['temp'],
@@ -542,9 +568,6 @@ class DynamicExtractor:
         h_heavy = self.Liquid_1.getEnthalpy(mole_frac=di_init['y_i'],
                                             temp=di_init['temp'],
                                             basis='mole')  # [J/mol]
-
-        # u_int = di_init['holdup_light'] * h_light \
-        #     + di_init['holdup_heavy'] * h_heavy
 
         u_int = res.mol_light * h_light + res.mol_heavy * h_heavy  # [J]
 
@@ -582,7 +605,6 @@ class DynamicExtractor:
         args_eq = (di_init['temp'], mol_i, holdups)  # [K], [mol], [mol]
         x0 = np.column_stack((di_init['x_i'], di_init['y_i'])).ravel()  # [-]
 
-        optimopts = {'xtol': 2**(-52)}  # [-]
         frac_result = root(equilibrium_eqns, x0, args=args_eq)
 
         frac_noneq = frac_result.x  # mole fractions [-]
@@ -594,12 +616,28 @@ class DynamicExtractor:
         di_init['x_i'] = x_noneq
         di_init['y_i'] = y_noneq
 
-        # di_init['x_i'] = di_init['x_i'][:, idx_light]
-        # di_init['y_i'] = di_init['y_i'][:, idx_heavy]
-
         return di_init
 
     def solve_unit(self, runtime, sundials_opts=None, verbose=True):
+        """Integrate the dynamic extractor DAE model.
+
+        Parameters
+        ----------
+        runtime : float
+            Simulation duration [s].
+        sundials_opts : dict, optional
+            Solver option names and values forwarded to IDA.
+        verbose : bool, optional
+            If False, suppress solver output [-].
+
+        Returns
+        -------
+        time : ndarray
+            Simulated time points [s].
+        states : ndarray
+            Flattened state history. Mole fractions are [-], internal energy is
+            [J], and temperature is [K].
+        """
 
         di_init = self.initialize_model()
         di_init = {key: di_init[key] for key in self.name_states}
@@ -635,6 +673,22 @@ class DynamicExtractor:
         return time, states
 
     def retrieve_results(self, time, states):
+        """Store dynamic extractor profiles and outlet streams.
+
+        Parameters
+        ----------
+        time : array_like
+            Simulated time points [s].
+        states : ndarray
+            Flattened state history. Mole fractions are [-], internal energy is
+            [J], and temperature is [K].
+
+        Returns
+        -------
+        None
+            The method updates ``result``, ``outputs``, ``Outlet``, and
+            ``profiles_runs`` in place.
+        """
         time = np.asarray(time)
 
         indexes = {key: self.states_di[key].get('index', None)
@@ -691,6 +745,26 @@ class DynamicExtractor:
 
     def plot_profiles(self, times=None, stages=None, pick_comp=None,
                       **fig_kwargs):
+        """Plot dynamic extractor state profiles.
+
+        Parameters
+        ----------
+        times : array_like, optional
+            Time points to plot [s].
+        stages : array_like, optional
+            Stage positions to plot [-].
+        pick_comp : sequence, optional
+            Component indices or names to include [-].
+        **fig_kwargs
+            Matplotlib figure keyword arguments.
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+            Created figure.
+        axis : ndarray
+            Axes containing mole-fraction [-] and temperature [K] profiles.
+        """
 
         if pick_comp is None:
             states_plot = ('x_i', 'y_i', 'temp')

--- a/PharmaPy/DynamicExtraction.py
+++ b/PharmaPy/DynamicExtraction.py
@@ -90,33 +90,60 @@ class DynamicExtractor:
         self.default_output = 'feed'
 
     def _default_k_fun(self, x_light, x_heavy, temp):
-        """Return liquid-liquid distribution coefficients ``K_i`` [-].
+        """Return liquid-liquid distribution coefficients.
 
-        ``x_light`` and ``x_heavy`` are liquid mole fractions [-], and
-        ``temp`` is temperature [K]. Activity coefficients are dimensionless,
-        so their ratio is the dimensionless extraction equilibrium constant.
+        Parameters
+        ----------
+        x_light : ndarray
+            Light-phase liquid mole fractions [-].
+        x_heavy : ndarray
+            Heavy-phase liquid mole fractions [-].
+        temp : ndarray
+            Liquid temperature [K].
+
+        Returns
+        -------
+        ndarray
+            Distribution coefficients ``K_i = gamma_light/gamma_heavy`` [-].
+
+        Notes
+        -----
+        Activity coefficients are dimensionless, so their ratio is the
+        dimensionless extraction equilibrium constant.
         """
         gamma_light = self.Liquid_1.getActivityCoeff(
-            method=self.gamma_model, mole_frac=x_light, temp=temp)  # [-]
+            method=self.gamma_model, mole_frac=x_light, temp=temp)
 
         gamma_heavy = self.Liquid_1.getActivityCoeff(
-            method=self.gamma_model, mole_frac=x_heavy, temp=temp)  # [-]
+            method=self.gamma_model, mole_frac=x_heavy, temp=temp)
 
         return gamma_light / gamma_heavy  # K_i [-]
 
     def nomenclature(self):
+        """Create dynamic extractor state metadata.
+
+        Returns
+        -------
+        None
+            The method populates ``states_di``, ``name_states``,
+            ``dim_states``, ``states_in_dict``, ``alg_map``, ``fstates_di``,
+            and ``names_states_out`` on the instance.
+
+        Notes
+        -----
+        The current dynamic-extractor state vector contains light and heavy
+        liquid mole fractions [-], internal energy [J], and temperature [K].
+        It keeps the existing dictionary-based metadata structure used by the
+        result and plotting helpers; replacing that structure is outside this
+        #56 fix.
+        """
         num_comp = self.num_comp
         name_species = self.name_species
         self.states_di = {
-            # 'mol_i': {'dim': num_comp, 'units': 'mole', 'type': 'diff',
-            #           'index': name_species},
             'x_i': {'dim': num_comp, 'type': 'alg', 'index': name_species},
             'y_i': {'dim': num_comp, 'type': 'alg', 'index': name_species},
-            # 'holdup_light': {'dim': 1, 'type': 'alg', 'units': 'mole'},
-            # 'holdup_heavy': {'dim': 1, 'type': 'alg', 'units': 'mole'},
-            # 'top_flows': {'dim': 1, 'type': 'alg', 'units': 'mole/s'},
-            'u_int': {'dim': 1, 'type': 'diff', 'units': 'J'},
-            'temp': {'dim': 1, 'type': 'alg', 'units': 'K'}
+            'u_int': {'dim': 1, 'type': 'diff', 'units': '[J]'},
+            'temp': {'dim': 1, 'type': 'alg', 'units': '[K]'}
             }
 
         self.name_states = list(self.states_di.keys())
@@ -177,7 +204,7 @@ class DynamicExtractor:
         vol = di_states['holdup_heavy'][0] / rhos[0] + \
             di_states['holdup_light'][0] / rhos[1]
 
-        self.vol = vol / 1000  # m**3
+        self.vol = vol / 1000  # [m**3]
 
     def get_inputs(self, time):
         inputs = {key: get_inputs_new(time, inlet, self.states_in_dict) for

--- a/PharmaPy/DynamicExtraction.py
+++ b/PharmaPy/DynamicExtraction.py
@@ -282,6 +282,7 @@ class DynamicExtractor:
                           di_sdot, augm_arrays):
 
         x_augm, y_augm, temp_augm, light_flows, heavy_flows = augm_arrays
+        # Augmented mole fractions [-], temperatures [K], and flows [mol/s].
 
         # print(x_augm.sum(axis=1))
 
@@ -290,23 +291,25 @@ class DynamicExtractor:
         m_ij = k_ij / self.eff  # [-]
 
         # ---------- Differential block
+        # Component flow imbalance [mol/s].
         dxij_dt = y_augm[1:] * heavy_flows[1:, np.newaxis] \
             + x_augm[:-1] * light_flows[:-1, np.newaxis] \
             - y_augm[:-1] * heavy_flows[:-1, np.newaxis] \
             - x_augm[1:] * light_flows[1:, np.newaxis]
 
+        # Effective liquid holdup [mol].
         div = holdup_light[:, np.newaxis] + holdup_heavy[:, np.newaxis] * m_ij
 
-        dxij_dt *= 1 / div
+        dxij_dt *= 1 / div  # mole-fraction rate [1/s]
 
         # ---------- Algebraic block
         equilibrium_alg = m_ij * (x_augm[1:] - x_augm[:-1] * (1 - self.eff)) \
-            - y_i
+            - y_i  # [-]
 
         # ---------- Modify outputs for stage two on
         if self.num_stages > 1:
             deriv_term = holdup_heavy[0] * m_ij * (1 - self.eff) / div[1:] * \
-                dxij_dt[:-1]
+                dxij_dt[:-1]  # mole-fraction rate [1/s]
 
             dxij_dt[1:] += deriv_term
 
@@ -314,7 +317,7 @@ class DynamicExtractor:
             #     - y_i[1:]
 
         if di_sdot is not None:
-            dxij_dt = dxij_dt - di_sdot['x_i']
+            dxij_dt = dxij_dt - di_sdot['x_i']  # [1/s]
 
         # nij_alg = x_i * holdup_light[:, np.newaxis] \
         #     + y_i * holdup_heavy[:, np.newaxis] - mol_i
@@ -449,43 +452,43 @@ class DynamicExtractor:
 
         # ---------- Equilibrium correction for x_i and y_i
         def equilibrium_eqns(fracs, temp, mol_i, holdups):
-            var = fracs.reshape(self.num_stages, -1)
+            var = fracs.reshape(self.num_stages, -1)  # mole fractions [-]
 
-            xi = var[:, :self.num_comp]
-            yi = var[:, self.num_comp:2 * self.num_comp]
+            xi = var[:, :self.num_comp]  # light-phase mole fractions [-]
+            yi = var[:, self.num_comp:2 * self.num_comp]  # heavy-phase [-]
 
-            HR, HE = holdups
+            HR, HE = holdups  # liquid holdups [mol]
 
-            x_eqns = (HR * xi + HE * yi - mol_i) / HR
+            x_eqns = (HR * xi + HE * yi - mol_i) / HR  # [-]
 
             k_ij = self.k_fun(xi, yi, temp)  # K_i [-]
 
             m_ij = k_ij / self.eff  # [-]; TODO: stage-wise
 
-            y_eqns = np.zeros_like(yi)
+            y_eqns = np.zeros_like(yi)  # equilibrium residuals [-]
             y_eqns[0] = m_ij * xi[0] - yi[0]
 
             if self.num_stages > 1:
                 y_eqns[1:] = m_ij * (xi[1:] - xi[:-1] * (1 - self.eff)) - yi[1:]
 
-            eqns = np.column_stack((x_eqns, y_eqns)).ravel()
+            eqns = np.column_stack((x_eqns, y_eqns)).ravel()  # [-]
 
             return eqns
 
-        holdups = [res.mol_light, res.mol_heavy]
-        mol_i = res.mol_light * res.x_light + res.mol_heavy * res.x_heavy
+        holdups = [res.mol_light, res.mol_heavy]  # [mol]
+        mol_i = res.mol_light * res.x_light + res.mol_heavy * res.x_heavy  # [mol]
 
         args_eq = (di_init['temp'], mol_i, holdups)
-        x0 = np.column_stack((di_init['x_i'], di_init['y_i'])).ravel()
+        x0 = np.column_stack((di_init['x_i'], di_init['y_i'])).ravel()  # [-]
 
         optimopts = {'xtol': 2**(-52)}
         frac_result = root(equilibrium_eqns, x0, args=args_eq)
 
-        frac_noneq = frac_result.x
+        frac_noneq = frac_result.x  # mole fractions [-]
 
         frac_noneq = frac_noneq.reshape(self.num_stages, -1)
 
-        x_noneq, y_noneq = np.split(frac_noneq, 2, axis=1)
+        x_noneq, y_noneq = np.split(frac_noneq, 2, axis=1)  # [-]
 
         di_init['x_i'] = x_noneq
         di_init['y_i'] = y_noneq

--- a/PharmaPy/DynamicExtraction.py
+++ b/PharmaPy/DynamicExtraction.py
@@ -285,10 +285,9 @@ class DynamicExtractor:
         x_augm, y_augm, temp_augm, light_flows, heavy_flows = augm_arrays
         # Augmented mole fractions [-], temperatures [K], and flows [mol/s].
 
-        # print(x_augm.sum(axis=1))
-
         # ---------- Equilibrium
-        k_ij = self.k_fun(x_i, y_i, temp)  # K_i [-]; TODO: stage-wise
+        # Stage-wise ``K_i`` callback support is tracked in #123.
+        k_ij = self.k_fun(x_i, y_i, temp)  # K_i [-]
         m_ij = k_ij / self.eff  # [-]
 
         # ---------- Differential block
@@ -314,28 +313,10 @@ class DynamicExtractor:
 
             dxij_dt[1:] += deriv_term
 
-            # equilibrium_alg[1:] = m_ij * (x_i[1:] - x_i[:-1] * (1 - self.eff)) \
-            #     - y_i[1:]
-
         if di_sdot is not None:
             dxij_dt = dxij_dt - di_sdot['x_i']  # [1/s]
 
-        # nij_alg = x_i * holdup_light[:, np.newaxis] \
-        #     + y_i * holdup_heavy[:, np.newaxis] - mol_i
-
-        # equilibrium_alg = m_ij * (x_augm[1:] - x_augm[:-1] * (1 - self.eff)) \
-        #     - y_i
-
-        # global_alg = holdup_light + holdup_heavy - mol_i.sum(axis=1)
-        # volume_alg = holdup_light/rho_light + holdup_heavy/rho_heavy \
-        #     - self.vol * 1000
-
         out = [dxij_dt, equilibrium_alg]
-
-        # di_flows = {'heavy': {'in': heavy_flows[1], 'out': heavy_flows[0]},
-        #             'light': {'in': light_flows[0], 'out': light_flows[1]}}
-
-        # print(di_flows)
 
         return out
 
@@ -464,7 +445,8 @@ class DynamicExtractor:
 
             k_ij = self.k_fun(xi, yi, temp)  # K_i [-]
 
-            m_ij = k_ij / self.eff  # [-]; TODO: stage-wise
+            # Stage-wise ``K_i`` callback support is tracked in #123.
+            m_ij = k_ij / self.eff  # [-]
 
             y_eqns = np.zeros_like(yi)  # equilibrium residuals [-]
             y_eqns[0] = m_ij * xi[0] - yi[0]

--- a/PharmaPy/Extractors.py
+++ b/PharmaPy/Extractors.py
@@ -54,6 +54,17 @@ def material_setter(instance, oper_mode):
     return out
 
 
+VALID_GAMMA_METHODS = ('ideal', 'UNIFAC', 'UNIQUAC')
+
+
+def validate_gamma_method(gamma_method, param_name='gamma_method'):
+    """Validate activity-coefficient model selectors."""
+    if gamma_method not in VALID_GAMMA_METHODS:
+        raise ValueError(
+            f"{param_name} must be one of {VALID_GAMMA_METHODS}, "
+            f"got {gamma_method!r}")
+
+
 class ContinuousExtractor:
     def __init__(self, k_fun=None, gamma_method='UNIQUAC'):
         """Create a continuous extractor.
@@ -67,6 +78,7 @@ class ContinuousExtractor:
         gamma_method : {'ideal', 'UNIFAC', 'UNIQUAC'}, optional
             Activity-coefficient method used by the default ``k_fun``.
         """
+        validate_gamma_method(gamma_method)
 
         self._Inlet = None
 

--- a/PharmaPy/Extractors.py
+++ b/PharmaPy/Extractors.py
@@ -31,17 +31,19 @@ def material_setter(instance, oper_mode):
     Returns
     -------
     out : dict
-        Inlet metadata with ``in_flow`` in mol/s for continuous operation or
-        mol for batch operation, ``temp`` [K], ``pres`` [Pa], component count,
-        and result-state metadata.
+        Inlet metadata with ``in_flow`` in [mol/s] for continuous operation or
+        [mol] for batch operation, ``temp`` [K], ``pres`` [Pa], component
+        count, and result-state metadata.
     """
     name_comp = instance.name_species
     num_comp = len(name_comp)
     states_di = {
-        'x_heavy': {'dim': num_comp, 'type': 'alg', 'index': name_comp},
-        'x_light': {'dim': num_comp, 'type': 'alg', 'index': name_comp},
-        'moles_heavy': {'dim': 1, 'type': 'alg'},
-        'moles_light': {'dim': 1, 'type': 'alg'}}
+        'x_heavy': {'dim': num_comp, 'type': 'alg', 'index': name_comp,
+                    'units': '[-]'},
+        'x_light': {'dim': num_comp, 'type': 'alg', 'index': name_comp,
+                    'units': '[-]'},
+        'moles_heavy': {'dim': 1, 'type': 'alg', 'units': '[mol]'},
+        'moles_light': {'dim': 1, 'type': 'alg', 'units': '[mol]'}}
 
     if oper_mode == 'Continuous':
         in_flow = instance.mole_flow
@@ -223,20 +225,40 @@ class ContinuousExtractor:
         return phi_conv, x1_conv, x2_conv, info
 
     def energy_balance(self, liq, vap, x_i, y_i, z_i):
-        liq_flow = liq * self.in_flow  # mol/s
-        vap_flow = vap * self.in_flow  # mol/s
+        """Evaluate the continuous extractor energy residual.
 
-        tref = self.temp
+        Parameters
+        ----------
+        liq : float
+            Liquid split fraction [-].
+        vap : float
+            Extract phase split fraction [-].
+        x_i : ndarray
+            Liquid outlet mole fractions [-].
+        y_i : ndarray
+            Extract outlet mole fractions [-].
+        z_i : ndarray
+            Feed mole fractions [-].
 
-        h_liq = 0
+        Returns
+        -------
+        float
+            Heat duty for the outlet-minus-inlet enthalpy balance [J/s].
+        """
+        liq_flow = liq * self.in_flow  # [mol/s]
+        vap_flow = vap * self.in_flow  # [mol/s]
+
+        tref = self.temp  # [K]
+
+        h_liq = 0  # [J/mol]
         h_vap = self.VaporOut.getEnthalpy(self.temp, temp_ref=tref,
-                                          mole_frac=y_i, basis='mole')
+                                          mole_frac=y_i, basis='mole')  # [J/mol]
 
-        h_in = self.matter.getEnthalpy(temp_ref=tref, basis='mole')
+        h_in = self.matter.getEnthalpy(temp_ref=tref, basis='mole')  # [J/mol]
 
-        heat_duty = liq_flow * h_liq + vap_flow * h_vap - self.in_flow * h_in
+        heat_duty = liq_flow * h_liq + vap_flow * h_vap - self.in_flow * h_in  # [J/s]
 
-        return heat_duty  # W
+        return heat_duty  # [J/s]
 
     def unit_model(self, phi, x1, x2, temp, material=True):
         z_i = self.matter.mole_frac

--- a/PharmaPy/Extractors.py
+++ b/PharmaPy/Extractors.py
@@ -56,6 +56,17 @@ def material_setter(instance, oper_mode):
 
 class ContinuousExtractor:
     def __init__(self, k_fun=None, gamma_method='UNIQUAC'):
+        """Create a continuous extractor.
+
+        Parameters
+        ----------
+        k_fun : callable, optional
+            Equilibrium function. It must accept two liquid mole-fraction
+            vectors ``x1`` [-] and ``x2`` [-] plus temperature ``temp`` [K],
+            and return distribution coefficients ``K_i`` [-].
+        gamma_method : {'ideal', 'UNIFAC', 'UNIQUAC'}, optional
+            Activity-coefficient method used by the default ``k_fun``.
+        """
 
         self._Inlet = None
 
@@ -113,13 +124,13 @@ class ContinuousExtractor:
         def get_ki(x1, x2, temp):
             gamma_1 = self.matter.getActivityCoeff(method=self.gamma_method,
                                                    mole_frac=x1,
-                                                   temp=temp)
+                                                   temp=temp)  # [-]
 
             gamma_2 = self.matter.getActivityCoeff(method=self.gamma_method,
                                                    mole_frac=x2,
-                                                   temp=temp)
+                                                   temp=temp)  # [-]
 
-            k_i = gamma_1 / gamma_2
+            k_i = gamma_1 / gamma_2  # K_i [-]
 
             return k_i
 
@@ -129,11 +140,13 @@ class ContinuousExtractor:
             k_fun = self.k_fun
 
         def func_phi(phi, k_i):
+            # phi, z_i, and K_i are dimensionless, so f_phi is dimensionless.
             f_phi = z_i * (1 - k_i) / (1 + phi*(k_i - 1))
 
             return f_phi.sum()
 
         def deriv_phi(phi, k_i):
+            # d(f_phi)/d(phi) is dimensionless because phi is dimensionless.
             deriv = z_i * (1 - k_i)**2 / (1 + phi*(k_i - 1))**2
 
             return deriv.sum()
@@ -146,7 +159,7 @@ class ContinuousExtractor:
         count = 0
 
         while error > tol and count < max_iter:
-            k_i = k_fun(x_1_seed, x_2_seed, self.temp)
+            k_i = k_fun(x_1_seed, x_2_seed, self.temp)  # K_i [-]
             phi_k = newton(func_phi, phi_seed, args=(k_i, ), fprime=deriv_phi)
 
             x_1_k = z_i / (1 + phi_k*(k_i - 1))

--- a/PharmaPy/Extractors.py
+++ b/PharmaPy/Extractors.py
@@ -58,7 +58,20 @@ VALID_GAMMA_METHODS = ('ideal', 'UNIFAC', 'UNIQUAC')
 
 
 def validate_gamma_method(gamma_method, param_name='gamma_method'):
-    """Validate activity-coefficient model selectors."""
+    """Validate an activity-coefficient model selector.
+
+    Parameters
+    ----------
+    gamma_method : {'ideal', 'UNIFAC', 'UNIQUAC'}
+        Activity-coefficient model selector.
+    param_name : str, optional
+        Parameter name to use in the validation error.
+
+    Raises
+    ------
+    ValueError
+        If ``gamma_method`` is not one of ``VALID_GAMMA_METHODS``.
+    """
     if gamma_method not in VALID_GAMMA_METHODS:
         raise ValueError(
             f"{param_name} must be one of {VALID_GAMMA_METHODS}, "

--- a/PharmaPy/Extractors.py
+++ b/PharmaPy/Extractors.py
@@ -97,29 +97,35 @@ class ContinuousExtractor:
 
         gamma_extr = self.matter.getActivityCoeff(method=self.gamma_method,
                                                   mole_frac=x_extr,
-                                                  temp=self.temp)
+                                                  temp=self.temp)  # [-]
 
         gamma_raff = self.matter.getActivityCoeff(method=self.gamma_method,
                                                   mole_frac=x_raff,
-                                                  temp=self.temp)
+                                                  temp=self.temp)  # [-]
 
-        global_bce = 1 - extr - raff
-        comp_bces = z_i - extr*x_extr - raff*x_raff
-        equilibria = x_extr * gamma_extr - x_raff * gamma_raff
+        global_bce = 1 - extr - raff  # [-]
+        comp_bces = z_i - extr*x_extr - raff*x_raff  # [-]
+        equilibria = x_extr * gamma_extr - x_raff * gamma_raff  # [-]
 
-        diff_frac = np.sum(x_extr - x_raff)
-        args_mid = np.array([raff, diff_frac, raff - 1])
-        vap_flow = mid_fn(args_mid)
+        diff_frac = np.sum(x_extr - x_raff)  # [-]
+        args_mid = np.array([raff, diff_frac, raff - 1])  # [-]
+        vap_flow = mid_fn(args_mid)  # phase-presence residual [-]
 
         balance = np.concatenate(
             (np.array([global_bce]),
              comp_bces, equilibria,
              np.array([vap_flow]))
             )
+        # All entries are dimensionless material/equilibrium residuals [-].
 
         return balance
 
     def material_balance(self, phi_seed, x_1_seed, x_2_seed, z_i, temp):
+        """Solve dimensionless liquid split and equilibrium relations.
+
+        ``phi_seed`` is a phase fraction [-], ``x_1_seed``, ``x_2_seed``,
+        and ``z_i`` are mole fractions [-], and ``temp`` is temperature [K].
+        """
 
         def get_ki(x1, x2, temp):
             gamma_1 = self.matter.getActivityCoeff(method=self.gamma_method,
@@ -160,19 +166,20 @@ class ContinuousExtractor:
 
         while error > tol and count < max_iter:
             k_i = k_fun(x_1_seed, x_2_seed, self.temp)  # K_i [-]
-            phi_k = newton(func_phi, phi_seed, args=(k_i, ), fprime=deriv_phi)
+            phi_k = newton(func_phi, phi_seed, args=(k_i, ),
+                           fprime=deriv_phi)  # phase fraction [-]
 
-            x_1_k = z_i / (1 + phi_k*(k_i - 1))
-            x_2_k = x_1_k * k_i
+            x_1_k = z_i / (1 + phi_k*(k_i - 1))  # mole fractions [-]
+            x_2_k = x_1_k * k_i  # mole fractions [-]
 
             # Normalize x's
             x_1_k *= 1 / x_1_k.sum()
             x_2_k *= 1 / x_2_k.sum()
 
-            x_k = np.concatenate((x_1_k, x_2_k))
-            x_km1 = np.concatenate((x_1_seed, x_2_seed))
+            x_k = np.concatenate((x_1_k, x_2_k))  # mole fractions [-]
+            x_km1 = np.concatenate((x_1_seed, x_2_seed))  # [-]
 
-            error = np.linalg.norm(x_k - x_km1)
+            error = np.linalg.norm(x_k - x_km1)  # [-]
 
             # Update
             x_1_seed = x_1_k

--- a/PharmaPy/Plotting.py
+++ b/PharmaPy/Plotting.py
@@ -64,6 +64,37 @@ def latexify_name(name, units=False):
     return out
 
 
+def format_unit_label(units):
+    """Return a display label for unit metadata.
+
+    Parameters
+    ----------
+    units : str or None
+        Unit metadata. Bracketed values such as ``[K]`` and ``[-]`` follow the
+        repository documentation convention.
+
+    Returns
+    -------
+    str
+        LaTeX-formatted unit label without metadata brackets. Dimensionless
+        metadata ``[-]`` and empty values return an empty string.
+    """
+    if units is None:
+        return ''
+
+    units = str(units).strip()
+    if units == '':
+        return ''
+
+    if units.startswith('[') and units.endswith(']'):
+        units = units[1:-1].strip()
+
+    if units in ('', '-'):
+        return ''
+
+    return latexify_name(units, units=True)
+
+
 def color_axis(ax, color):
     ax.spines['right'].set_color(color)
     ax.tick_params(axis='y', colors=color, which='both')
@@ -182,8 +213,8 @@ def name_yaxes(ax, states_fstates, names, ylabels, legend):
             ylabel = latexify_name(ylabels[ind])
 
         units = states_fstates[name].get('units', '')
-        if len(units) > 0:
-            unit_name = latexify_name(units, units=True)
+        unit_name = format_unit_label(units)
+        if len(unit_name) > 0:
             ylabel = ylabel + ' (' + unit_name + ')'
 
         axis.set_ylabel(ylabel)
@@ -265,9 +296,8 @@ def plot_function(uo, state_names, axes=None, fig_map=None, ylabels=None,
             ylabel = latexify_name(ylabels[ind])
 
         units = states_and_fstates[name].get('units', '')
-        if len(units) > 0:
-            unit_name = latexify_name(states_and_fstates[name]['units'],
-                                      units=True)
+        unit_name = format_unit_label(units)
+        if len(unit_name) > 0:
             ylabel = ylabel + ' (' + unit_name + ')'
 
         if index_y:

--- a/tests/assimulo_helpers.py
+++ b/tests/assimulo_helpers.py
@@ -1,0 +1,86 @@
+"""Helpers for tests that import optional Assimulo-backed modules."""
+
+import importlib
+import sys
+from types import ModuleType
+
+
+def _stub_assimulo_modules(monkeypatch, *, solvers, problem):
+    """Register a minimal temporary Assimulo module tree.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Pytest cleanup fixture used to restore ``sys.modules``.
+    solvers : dict
+        Solver attributes to expose on ``assimulo.solvers``.
+    problem : dict
+        Problem attributes to expose on ``assimulo.problem``.
+
+    Notes
+    -----
+    This monkeypatch is limited to optional import availability in test
+    environments where Assimulo is not installed. It does not implement solver
+    behavior; solver-backed integration coverage remains in Assimulo-enabled
+    environments.
+    """
+    assimulo = ModuleType("assimulo")
+
+    solvers_module = ModuleType("assimulo.solvers")
+    for name, value in solvers.items():
+        setattr(solvers_module, name, value)
+
+    problem_module = ModuleType("assimulo.problem")
+    for name, value in problem.items():
+        setattr(problem_module, name, value)
+
+    exception = ModuleType("assimulo.exception")
+    exception.TerminateSimulation = Exception
+
+    monkeypatch.setitem(sys.modules, "assimulo", assimulo)
+    monkeypatch.setitem(sys.modules, "assimulo.solvers", solvers_module)
+    monkeypatch.setitem(sys.modules, "assimulo.problem", problem_module)
+    monkeypatch.setitem(sys.modules, "assimulo.exception", exception)
+
+
+def import_module_with_assimulo_stub(monkeypatch, module_name, *,
+                                     solvers, problem):
+    """Import a module, stubbing only optional Assimulo imports if needed.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Pytest cleanup fixture used only when the import needs stubbing.
+    module_name : str
+        Dotted module path to import.
+    solvers : dict
+        Solver attributes to expose on ``assimulo.solvers``.
+    problem : dict
+        Problem attributes to expose on ``assimulo.problem``.
+
+    Returns
+    -------
+    module
+        Imported module.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If a dependency other than optional Assimulo is missing.
+
+    Notes
+    -----
+    The temporary monkeypatch is justified because these unit tests exercise
+    constructor and handoff logic that can run without Assimulo, while the full
+    solver suite is only available when the optional Assimulo dependency is
+    installed.
+    """
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name != "assimulo":
+            raise
+
+        _stub_assimulo_modules(monkeypatch, solvers=solvers, problem=problem)
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+        return importlib.import_module(module_name)

--- a/tests/test_dynamic_extractor_default_k_fun.py
+++ b/tests/test_dynamic_extractor_default_k_fun.py
@@ -75,7 +75,7 @@ def test_default_k_fun_rejects_unknown_activity_model(monkeypatch):
 
 
 def test_initialize_model_passes_default_k_fun_to_batch_extractor(monkeypatch):
-    """The default constructor supplies ``BatchExtractor`` a callable k_fun.
+    """The default constructor supplies ``BatchExtractor`` the selected model.
 
     This pins the DynamicExtractor -> BatchExtractor handoff without running a
     full static extraction solve. The real solve depends on thermodynamic phase
@@ -86,15 +86,16 @@ def test_initialize_model_passes_default_k_fun_to_batch_extractor(monkeypatch):
     captured = {}
 
     class _BatchExtractor:
-        def __init__(self, k_fun=None):
+        def __init__(self, k_fun=None, gamma_method="UNIQUAC"):
             captured["k_fun"] = k_fun
+            captured["gamma_method"] = gamma_method
 
         def solve_unit(self):
             raise _StopAfterConstruction
 
     monkeypatch.setattr(module, "BatchExtractor", _BatchExtractor)
 
-    extractor = module.DynamicExtractor(num_stages=1)
+    extractor = module.DynamicExtractor(num_stages=1, gamma_model="ideal")
     extractor.Liquid_1 = object()
 
     with pytest.raises(_StopAfterConstruction):
@@ -102,3 +103,4 @@ def test_initialize_model_passes_default_k_fun_to_batch_extractor(monkeypatch):
 
     assert captured["k_fun"] is extractor.k_fun
     assert callable(captured["k_fun"])
+    assert captured["gamma_method"] == "ideal"

--- a/tests/test_dynamic_extractor_default_k_fun.py
+++ b/tests/test_dynamic_extractor_default_k_fun.py
@@ -42,6 +42,10 @@ class _ActivityPhase:
         return 1.0 + 0.5 * np.asarray(mole_frac)  # gamma_i [-]
 
 
+class _StopAfterConstruction(Exception):
+    """Raised by the stub to stop initialization at a known point."""
+
+
 def test_default_k_fun_uses_selected_activity_model(monkeypatch):
     """The default DynamicExtractor k_fun returns gamma_light/gamma_heavy."""
     module = _load_dynamic_extraction(monkeypatch)
@@ -63,6 +67,14 @@ def test_default_k_fun_uses_selected_activity_model(monkeypatch):
     assert extractor.Liquid_1.calls[0][2] == pytest.approx(temp)
 
 
+def test_default_k_fun_rejects_unknown_activity_model(monkeypatch):
+    """DynamicExtractor rejects unknown default activity-model selectors."""
+    module = _load_dynamic_extraction(monkeypatch)
+
+    with pytest.raises(ValueError, match="gamma_model must be one of"):
+        module.DynamicExtractor(num_stages=1, gamma_model="uniquac")
+
+
 def test_initialize_model_passes_default_k_fun_to_batch_extractor(monkeypatch):
     """The default constructor supplies a callable equilibrium function."""
     module = _load_dynamic_extraction(monkeypatch)
@@ -72,12 +84,15 @@ def test_initialize_model_passes_default_k_fun_to_batch_extractor(monkeypatch):
         def __init__(self, k_fun=None):
             captured["k_fun"] = k_fun
 
+        def solve_unit(self):
+            raise _StopAfterConstruction
+
     monkeypatch.setattr(module, "BatchExtractor", _BatchExtractor)
 
     extractor = module.DynamicExtractor(num_stages=1)
     extractor.Liquid_1 = object()
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(_StopAfterConstruction):
         extractor.initialize_model()
 
     assert captured["k_fun"] is extractor.k_fun

--- a/tests/test_dynamic_extractor_default_k_fun.py
+++ b/tests/test_dynamic_extractor_default_k_fun.py
@@ -1,36 +1,33 @@
 """Regression tests for DynamicExtractor default equilibrium routing."""
 
-import importlib
-import sys
-import types
-
 import numpy as np
 import pytest
+
+from assimulo_helpers import import_module_with_assimulo_stub
 
 
 pytestmark = pytest.mark.unit
 
 
 def _load_dynamic_extraction(monkeypatch):
-    """Import DynamicExtraction with a minimal solver stub for unit tests."""
-    assimulo = types.ModuleType("assimulo")
-    problem = types.ModuleType("assimulo.problem")
-    solvers = types.ModuleType("assimulo.solvers")
+    """Import DynamicExtraction while stubbing only optional Assimulo symbols.
 
-    class _UnavailableSolver:
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError("solver stub is not executable")
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Pytest cleanup fixture used by the shared optional-import helper.
 
-    problem.Implicit_Problem = object
-    solvers.IDA = _UnavailableSolver
-    solvers.Radau5DAE = _UnavailableSolver
-
-    monkeypatch.setitem(sys.modules, "assimulo", assimulo)
-    monkeypatch.setitem(sys.modules, "assimulo.problem", problem)
-    monkeypatch.setitem(sys.modules, "assimulo.solvers", solvers)
-    monkeypatch.delitem(sys.modules, "PharmaPy.DynamicExtraction", raising=False)
-
-    return importlib.import_module("PharmaPy.DynamicExtraction")
+    Returns
+    -------
+    module
+        Imported ``PharmaPy.DynamicExtraction`` module.
+    """
+    return import_module_with_assimulo_stub(
+        monkeypatch,
+        "PharmaPy.DynamicExtraction",
+        solvers={"IDA": object, "Radau5DAE": object},
+        problem={"Implicit_Problem": object},
+    )
 
 
 class _ActivityPhase:
@@ -54,7 +51,7 @@ def test_default_k_fun_uses_selected_activity_model(monkeypatch):
 
     x_light = np.array([[0.2, 0.8], [0.4, 0.6]])  # [-]
     x_heavy = np.array([[0.5, 0.5], [0.1, 0.9]])  # [-]
-    temp = np.array([298.15, 301.15])  # K
+    temp = np.array([298.15, 301.15])  # [K]
 
     k_i = extractor.k_fun(x_light, x_heavy, temp)  # K_i [-]
 

--- a/tests/test_dynamic_extractor_default_k_fun.py
+++ b/tests/test_dynamic_extractor_default_k_fun.py
@@ -1,0 +1,84 @@
+"""Regression tests for DynamicExtractor default equilibrium routing."""
+
+import importlib
+import sys
+import types
+
+import numpy as np
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def _load_dynamic_extraction(monkeypatch):
+    """Import DynamicExtraction with a minimal solver stub for unit tests."""
+    assimulo = types.ModuleType("assimulo")
+    problem = types.ModuleType("assimulo.problem")
+    solvers = types.ModuleType("assimulo.solvers")
+
+    class _UnavailableSolver:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("solver stub is not executable")
+
+    problem.Implicit_Problem = object
+    solvers.IDA = _UnavailableSolver
+    solvers.Radau5DAE = _UnavailableSolver
+
+    monkeypatch.setitem(sys.modules, "assimulo", assimulo)
+    monkeypatch.setitem(sys.modules, "assimulo.problem", problem)
+    monkeypatch.setitem(sys.modules, "assimulo.solvers", solvers)
+    monkeypatch.delitem(sys.modules, "PharmaPy.DynamicExtraction", raising=False)
+
+    return importlib.import_module("PharmaPy.DynamicExtraction")
+
+
+class _ActivityPhase:
+    def __init__(self):
+        self.calls = []
+
+    def getActivityCoeff(self, method, mole_frac, temp):
+        self.calls.append((method, np.asarray(mole_frac), np.asarray(temp)))
+        return 1.0 + 0.5 * np.asarray(mole_frac)
+
+
+def test_default_k_fun_uses_selected_activity_model(monkeypatch):
+    """The default DynamicExtractor k_fun returns gamma_light/gamma_heavy."""
+    module = _load_dynamic_extraction(monkeypatch)
+    extractor = module.DynamicExtractor(num_stages=2, gamma_model="UNIFAC")
+    extractor.Liquid_1 = _ActivityPhase()
+
+    x_light = np.array([[0.2, 0.8], [0.4, 0.6]])  # [-]
+    x_heavy = np.array([[0.5, 0.5], [0.1, 0.9]])  # [-]
+    temp = np.array([298.15, 301.15])  # K
+
+    k_i = extractor.k_fun(x_light, x_heavy, temp)
+
+    expected = (1.0 + 0.5 * x_light) / (1.0 + 0.5 * x_heavy)
+    assert k_i == pytest.approx(expected)
+    assert [call[0] for call in extractor.Liquid_1.calls] == [
+        "UNIFAC",
+        "UNIFAC",
+    ]
+    assert extractor.Liquid_1.calls[0][2] == pytest.approx(temp)
+
+
+def test_initialize_model_passes_default_k_fun_to_batch_extractor(monkeypatch):
+    """The default constructor supplies a callable equilibrium function."""
+    module = _load_dynamic_extraction(monkeypatch)
+    captured = {}
+
+    class _BatchExtractor:
+        def __init__(self, k_fun=None):
+            captured["k_fun"] = k_fun
+
+    monkeypatch.setattr(module, "BatchExtractor", _BatchExtractor)
+
+    extractor = module.DynamicExtractor(num_stages=1)
+    extractor.Liquid_1 = object()
+
+    with pytest.raises(AttributeError):
+        extractor.initialize_model()
+
+    assert captured["k_fun"] is extractor.k_fun
+    assert callable(captured["k_fun"])

--- a/tests/test_dynamic_extractor_default_k_fun.py
+++ b/tests/test_dynamic_extractor_default_k_fun.py
@@ -39,7 +39,7 @@ class _ActivityPhase:
 
     def getActivityCoeff(self, method, mole_frac, temp):
         self.calls.append((method, np.asarray(mole_frac), np.asarray(temp)))
-        return 1.0 + 0.5 * np.asarray(mole_frac)
+        return 1.0 + 0.5 * np.asarray(mole_frac)  # gamma_i [-]
 
 
 def test_default_k_fun_uses_selected_activity_model(monkeypatch):
@@ -52,9 +52,9 @@ def test_default_k_fun_uses_selected_activity_model(monkeypatch):
     x_heavy = np.array([[0.5, 0.5], [0.1, 0.9]])  # [-]
     temp = np.array([298.15, 301.15])  # K
 
-    k_i = extractor.k_fun(x_light, x_heavy, temp)
+    k_i = extractor.k_fun(x_light, x_heavy, temp)  # K_i [-]
 
-    expected = (1.0 + 0.5 * x_light) / (1.0 + 0.5 * x_heavy)
+    expected = (1.0 + 0.5 * x_light) / (1.0 + 0.5 * x_heavy)  # [-]
     assert k_i == pytest.approx(expected)
     assert [call[0] for call in extractor.Liquid_1.calls] == [
         "UNIFAC",

--- a/tests/test_dynamic_extractor_default_k_fun.py
+++ b/tests/test_dynamic_extractor_default_k_fun.py
@@ -71,12 +71,20 @@ def test_default_k_fun_rejects_unknown_activity_model(monkeypatch):
     """DynamicExtractor rejects unknown default activity-model selectors."""
     module = _load_dynamic_extraction(monkeypatch)
 
+    # Lowercase ``uniquac`` is deliberate: activity-model selectors are
+    # case-sensitive and must match the exact Phases.getActivityCoeff branch.
     with pytest.raises(ValueError, match="gamma_model must be one of"):
         module.DynamicExtractor(num_stages=1, gamma_model="uniquac")
 
 
 def test_initialize_model_passes_default_k_fun_to_batch_extractor(monkeypatch):
-    """The default constructor supplies a callable equilibrium function."""
+    """The default constructor supplies ``BatchExtractor`` a callable k_fun.
+
+    This pins the DynamicExtractor -> BatchExtractor handoff without running a
+    full static extraction solve. The real solve depends on thermodynamic phase
+    objects, outlet construction, and broader stage-wise K_i behavior tracked
+    separately in #123; the sentinel stops at the fixed boundary.
+    """
     module = _load_dynamic_extraction(monkeypatch)
     captured = {}
 

--- a/tests/test_extractor_modes.py
+++ b/tests/test_extractor_modes.py
@@ -15,10 +15,10 @@ pytestmark = pytest.mark.unit
 
 class _Inlet:
     name_species = ["solute", "solvent"]
-    mole_flow = 8.0  # mol/s
-    moles = 3.0  # mol
-    temp = 298.15  # K
-    pres = 101325.0  # Pa
+    mole_flow = 8.0  # [mol/s]
+    moles = 3.0  # [mol]
+    temp = 298.15  # [K]
+    pres = 101325.0  # [Pa]
     mole_frac = np.array([0.25, 0.75])  # [-]
     path_data = "dummy-path"
 
@@ -27,13 +27,13 @@ class _DummyOutlet:
     def __init__(self, path, mole_frac, temp, pres, **amount):
         self.path = path
         self.mole_frac = mole_frac  # [-]
-        self.temp = temp  # K
-        self.pres = pres  # Pa
+        self.temp = temp  # [K]
+        self.pres = pres  # [Pa]
         self.amount = amount  # mole_flow [mol/s] or moles [mol]
 
     def getDensity(self, basis):
         assert basis == "mole"
-        return 1000.0  # arbitrary molar density [mol/m^3]
+        return 1000.0  # [mol/m**3]
 
 
 class _DummyStream(_DummyOutlet):
@@ -45,7 +45,7 @@ class _DummyPhase(_DummyOutlet):
 
 
 def test_continuous_extractor_uses_mole_flow_and_stream_outlets(monkeypatch):
-    """Continuous extractor routes inlet and outlet quantities as mol/s."""
+    """Continuous extractor routes inlet and outlet quantities as [mol/s]."""
     created = {"stream": [], "phase": []}
 
     def stream_factory(*args, **kwargs):
@@ -87,7 +87,7 @@ def test_continuous_extractor_uses_mole_flow_and_stream_outlets(monkeypatch):
 
 
 def test_batch_extractor_keeps_batch_amount_semantics():
-    """Batch extractor keeps inlet amount semantics as mol."""
+    """Batch extractor keeps inlet amount semantics as [mol]."""
     extractor = BatchExtractor()
     extractor.Phases = _Inlet()
 

--- a/tests/test_extractor_modes.py
+++ b/tests/test_extractor_modes.py
@@ -93,3 +93,10 @@ def test_batch_extractor_keeps_batch_amount_semantics():
 
     assert extractor.oper_mode == "Batch"
     assert extractor.in_flow == pytest.approx(_Inlet.moles)
+
+
+@pytest.mark.parametrize("extractor_cls", [ContinuousExtractor, BatchExtractor])
+def test_extractors_reject_unknown_activity_model(extractor_cls):
+    """Extractor constructors reject unknown activity-model selectors."""
+    with pytest.raises(ValueError, match="gamma_method must be one of"):
+        extractor_cls(gamma_method="uniquac")

--- a/tests/test_extractor_modes.py
+++ b/tests/test_extractor_modes.py
@@ -96,7 +96,19 @@ def test_batch_extractor_keeps_batch_amount_semantics():
 
 
 @pytest.mark.parametrize("extractor_cls", [ContinuousExtractor, BatchExtractor])
+@pytest.mark.parametrize("gamma_method", ["ideal", "UNIFAC", "UNIQUAC"])
+def test_extractors_accept_documented_activity_models(extractor_cls,
+                                                     gamma_method):
+    """Extractor constructors accept the documented selector spellings."""
+    extractor = extractor_cls(gamma_method=gamma_method)
+
+    assert extractor.gamma_method == gamma_method
+
+
+@pytest.mark.parametrize("extractor_cls", [ContinuousExtractor, BatchExtractor])
 def test_extractors_reject_unknown_activity_model(extractor_cls):
     """Extractor constructors reject unknown activity-model selectors."""
+    # Lowercase ``uniquac`` is deliberate: the documented selector is the
+    # exact-cased ``UNIQUAC`` branch used by Phases.getActivityCoeff.
     with pytest.raises(ValueError, match="gamma_method must be one of"):
         extractor_cls(gamma_method="uniquac")

--- a/tests/test_plotting_unit_labels.py
+++ b/tests/test_plotting_unit_labels.py
@@ -1,0 +1,35 @@
+"""Regression tests for plotting unit metadata labels."""
+
+import matplotlib.pyplot as plt
+
+from PharmaPy.Plotting import format_unit_label, latexify_name, name_yaxes
+
+
+def test_format_unit_label_accepts_bracketed_metadata():
+    """Bracketed source metadata renders without nested brackets."""
+    temp_units = "[K]"
+    density_units = "[kg/m**3]"
+
+    assert format_unit_label(temp_units) == latexify_name(temp_units[1:-1], units=True)
+    assert format_unit_label(density_units) == latexify_name(
+        density_units[1:-1], units=True)
+
+
+def test_name_yaxes_suppresses_dimensionless_metadata():
+    """Dimensionless ``[-]`` metadata does not add a plot-label suffix."""
+    temp_units = "[K]"
+    fig, axes = plt.subplots(1, 2)
+    states = {
+        "temp": {"units": temp_units},
+        "x_liq": {"units": "[-]"},
+    }
+
+    try:
+        name_yaxes(axes, states, ("temp", "x_liq"), ("T", "x_liq"), True)
+
+        assert axes[0].get_ylabel() == (
+            f"{latexify_name('T')} ({latexify_name(temp_units[1:-1], units=True)})"
+        )
+        assert axes[1].get_ylabel() == latexify_name("x_liq")
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
Closes #56

## Summary
- Give `DynamicExtractor` a default `k_fun` that computes liquid-liquid distribution coefficients from activity-coefficient ratios.
- Store and validate the selected `gamma_model` on the dynamic extractor so the default callable honors the constructor option and rejects unknown model names.
- Validate the documented activity-model selector for `ContinuousExtractor` and `BatchExtractor` as well.
- Add solver-free regression tests for the default callable, invalid activity-model selectors, and the `initialize_model` handoff into `BatchExtractor`.
- Add exact-cased selector acceptance coverage for `ContinuousExtractor` and `BatchExtractor`.
- Add unit/docstring annotations in `PharmaPy/DynamicExtraction.py` and `PharmaPy/Extractors.py`; the `Extractors.py` annotations are scope/documentation only apart from the new selector validation.
- Remove stale commented-out DynamicExtraction algebra/debug blocks and replace hidden stage-wise `K_i` TODOs with the tracked follow-up #123.

## Acceptance Criteria
- [x] `DynamicExtractor(num_stages=...)` defines a callable equilibrium function when `k_fun` is omitted.
- [x] The default equilibrium function returns dimensionless `K_i = gamma_light / gamma_heavy` using the selected activity model.
- [x] `initialize_model` passes the default callable into `BatchExtractor` instead of failing on a missing `k_fun` attribute.
- [x] Unknown documented activity-model selectors raise `ValueError` instead of silently falling through to UNIFAC-Dortmund.

## Local Checks
- `conda run -n pharmapy python -m pytest tests/test_dynamic_extractor_default_k_fun.py tests/test_extractor_modes.py -q`
- `conda run -n pharmapy python -m pytest tests/ -m "not assimulo"`
- `conda run -n pharmapy python -m pytest --collect-only`
- Red check: copied the new invalid-model tests into a temporary worktree at `5ef2e0e`; they failed with `DID NOT RAISE ValueError` for `DynamicExtractor`, `ContinuousExtractor`, and `BatchExtractor`.

The original missing-`k_fun` regression was also run against unmodified `origin/master` in a temporary worktree and failed with the expected missing-`k_fun` `AttributeError`.

## Testing Scope
- A broader full-solve `DynamicExtractor.initialize_model()` integration test was not added in this PR because it would depend on static LLE solving, thermodynamic phase construction, density/enthalpy methods, and the stage-wise `K_i` contract now tracked in #123.
- The monkeypatched `BatchExtractor` test is intentionally scoped to the fixed caller-to-callee handoff: it verifies the default `k_fun` is passed into `BatchExtractor` and stops with a sentinel before unrelated solver/model behavior begins.

## Follow-Up
- #122 tracks the cross-module activity-model selector source-of-truth and naming cleanup intentionally deferred from this #56 fix.
- #123 tracks stage-wise `K_i` callback shape/validation support for `DynamicExtractor`.

## Branch Hygiene
- Base branch: `master`
- Source branch point: `0f89b71` (`origin/master`)
- Source branch: `fix/issue-56-dynamic-extractor-kfun`
- Stacked status: not stacked
- Open PR overlap: none found for `PharmaPy/DynamicExtraction.py`, `PharmaPy/Extractors.py`, `tests/test_dynamic_extractor_default_k_fun.py`, or `tests/test_extractor_modes.py`

<!-- gh-arc:metadata=start -->
## Review Follow-Up Metadata

<!-- gh-arc:metadata=review-audit-follow-up:sha=7d0c7fa6b8102e85491454544aa484c73dcac2a1 -->

- Pushed `7d0c7fa` directly to existing branch `fix/issue-56-dynamic-extractor-kfun`.
- Addressed in-scope review suggestions by forwarding `gamma_model` into the nested `BatchExtractor`, asserting that handoff in the focused test, documenting `get_alg_map`, `complete_molefrac`, `unit_model`, `solve_unit`, `retrieve_results`, and `plot_profiles`, and removing stale debug/commented blocks plus unused `optimopts`.
- Kept bracketed `states_di` metadata by convention; added `Plotting.format_unit_label` and focused tests so `[K]` and `[-]` metadata render without nested plot-label brackets or dimensionless suffixes.
- Monkeypatch rationale: the remaining `BatchExtractor` sentinel only pins the constructor handoff boundary because the full staged dynamic solve is still deferred to #123; this is documented in the test helper/docstring and PR metadata.
- Verification: unit audit passed; focused tests `15 passed`; full suite `63 passed, 32 warnings`; diff check passed.
<!-- gh-arc:metadata=end -->
