### PR TITLE
Fix raw material OPEX accounting

### DIFF
--- a/PharmaPy/SimExec.py
+++ b/PharmaPy/SimExec.py
@@ -501,6 +501,9 @@ class SimulationExec:
         return out
 
     def get_raw_inlets(self, uo, basis='mass'):
+        if basis not in ('mass', 'mole'):
+            raise ValueError("basis must be either 'mass' or 'mole'")
+
         if hasattr(uo, 'Inlet'):
             if isinstance(uo.Inlet, dict):
                 inlets = uo.Inlet
@@ -523,7 +526,7 @@ class SimulationExec:
         out = {}
 
         for name, inlet in raws.items():
-            if inlet.__class__.__name__ == 'PharmaPy.MixedPhases':
+            if inlet.__module__ == 'PharmaPy.MixedPhases':
                 streams = inlet.Phases
             else:
                 streams = [inlet]
@@ -541,19 +544,23 @@ class SimulationExec:
                 if uo.oper_mode == 'Batch':
                     if basis == 'mass':
                         total = stream.mass
+                        di[name_stream] = {'mass': total}
+                        fields += ['mass_frac']
                     elif basis == 'mole':
                         total = stream.moles
+                        di[name_stream] = {'moles': total}
+                        fields += ['mole_frac']
                 elif inlet.DynamicInlet is None:
                     time = uo.result.time[-1] - uo.result.time[0]
                     if basis == 'mass':
-                        flow = inlet.mass_flow
+                        flow = stream.mass_flow
                         total = flow*time
 
                         di[name_stream] = {'mass': total}
                         fields += ['mass_frac', 'mass_flow', 'vol_flow']
 
                     else:
-                        flow = inlet.mole_flow
+                        flow = stream.mole_flow
                         total = flow*time
 
                         di[name_stream] = {'moles': total}
@@ -561,7 +568,7 @@ class SimulationExec:
 
                 else:
                     time = uo.result.time
-                    inputs = uo.Inlet.DynamicInlet.evaluate_inputs(time)
+                    inputs = inlet.DynamicInlet.evaluate_inputs(time)
 
                     if basis == 'mass':
                         if 'mass_flow' in inputs:
@@ -620,14 +627,44 @@ class SimulationExec:
 
         return out
 
-    def GetRawMaterials(self, basis='mass', totals=True, steady_state=False):
+    def GetRawMaterials(self, basis='mass', totals=True, steady_state=False,
+                        include_holdups=True):
+        """
+        Get raw material use for all solved unit operations.
+
+        Parameters
+        ----------
+        basis : {'mass', 'mole'}, optional
+            Accounting basis. Mass totals are reported in kg and molar totals
+            are reported in mol.
+        totals : bool, optional
+            If true, aggregate each raw stream into total and per-species
+            columns on the selected basis.
+        steady_state : bool, optional
+            Reserved for steady-state raw material accounting.
+        include_holdups : bool, optional
+            If true, include initial holdups that were not transferred from an
+            upstream unit operation.
+
+        Returns
+        -------
+        raw_df : pandas.DataFrame
+            Raw material table indexed by unit operation, raw source, and
+            stream or phase name.
+
+        """
+        if basis not in ('mass', 'mole'):
+            raise ValueError("basis must be either 'mass' or 'mole'")
 
         out = {}
         for name, uo in self.uos_instances.items():
             out[name] = {}
 
             raw_inlets = self.get_raw_inlets(uo, basis=basis)
-            raw_holdup = self.get_holdup(uo, basis=basis)
+            if include_holdups:
+                raw_holdup = self.get_holdup(uo, basis=basis)
+            else:
+                raw_holdup = {}
 
             for second in raw_inlets:  # flatten multidimensional states
                 for third in raw_inlets[second]:
@@ -669,7 +706,7 @@ class SimulationExec:
                     raw_df = pd.DataFrame(np.column_stack((mass, mass_comp)),
                                           columns=cols, index=raw_df.index)
 
-                elif basis == 'moles':
+                elif basis == 'mole':
                     mole_frac = raw_df.filter(regex='mole_frac').values
                     moles = raw_df['moles'].values[:, np.newaxis]
                     moles_comp = mole_frac * moles
@@ -729,6 +766,30 @@ class SimulationExec:
 
     def GetOPEX(self, cost_raw, include_holdups=True, steady_raw=False,
                 lumped=False, kwargs_items=None):
+        """
+        Get operating costs from duties, raw materials, and labor.
+
+        Parameters
+        ----------
+        cost_raw : array_like
+            Raw material unit costs compatible with the raw material table.
+        include_holdups : bool, optional
+            If true, raw material accounting includes initial holdups.
+        steady_raw : bool, optional
+            Forwarded to ``GetRawMaterials`` for steady-state raw accounting.
+        lumped : bool, optional
+            Reserved for lumped OPEX reporting.
+        kwargs_items : dict, optional
+            Per-item keyword arguments for ``duties``, ``raw_materials``, and
+            ``labor`` calculations.
+
+        Returns
+        -------
+        duty_cost, raw_cost, labor_cost : pandas.DataFrame
+            Operating-cost components for the solved flowsheet when ``lumped``
+            is false.
+
+        """
 
         opex_items = ('duties', 'raw_materials', 'labor')
         if kwargs_items is None:
@@ -755,9 +816,11 @@ class SimulationExec:
         duty_cost = np.abs(duties)*1e-9 * duty_unit_cost
 
         # ---------- Raw materials
-        raw_materials = self.GetRawMaterials(
-            include_holdups, steady_raw, **kwargs_items.get('raw_materials',
-                                                            {}))
+        raw_kwargs = kwargs_items.get('raw_materials', {}).copy()
+        raw_kwargs['steady_state'] = steady_raw
+        raw_kwargs['include_holdups'] = include_holdups
+
+        raw_materials = self.GetRawMaterials(**raw_kwargs)
         raw_cost = cost_raw * raw_materials
 
         # ---------- Labor

--- a/PharmaPy/SimExec.py
+++ b/PharmaPy/SimExec.py
@@ -532,7 +532,8 @@ class SimulationExec:
         -------
         dict
             Dynamic input profiles. Flow entries are [kg/s], [mol/s], or
-            [m**3/s] according to their key; temperature is [K].
+            [m**3/s] according to their key; temperature is [K] and pressure is
+            [Pa].
 
         Notes
         -----
@@ -749,7 +750,9 @@ class SimulationExec:
             If true, aggregate each raw stream into total and per-species
             columns on the selected basis.
         steady_state : bool, optional
-            Reserved for steady-state raw material accounting.
+            Reserved for future steady-state raw material accounting. It is
+            accepted for API compatibility but currently does not change the
+            returned table.
         include_holdups : bool, optional
             If true, include initial holdups that were not transferred from an
             upstream unit operation.
@@ -761,6 +764,10 @@ class SimulationExec:
             stream or phase name. Total columns are [kg] or [mol], and
             per-species columns use the same selected basis.
 
+        Raises
+        ------
+        ValueError
+            If ``basis`` is not ``'mass'`` or ``'mole'``.
         """
         if basis not in ('mass', 'mole'):
             raise ValueError("basis must be either 'mass' or 'mole'")
@@ -889,7 +896,9 @@ class SimulationExec:
         include_holdups : bool, optional
             If true, raw material accounting includes initial holdups.
         steady_raw : bool, optional
-            Forwarded to ``GetRawMaterials`` for steady-state raw accounting.
+            Forwarded to ``GetRawMaterials``. It is reserved for future
+            steady-state raw accounting and currently does not change the raw
+            material table.
         lumped : bool, optional
             Reserved for lumped OPEX reporting.
         kwargs_items : dict, optional
@@ -903,6 +912,13 @@ class SimulationExec:
         duty_cost, raw_cost, labor_cost : pandas.DataFrame
             ``duty_cost`` [USD] and ``raw_cost`` [USD] are per simulated run.
             ``labor_cost`` is [USD/yr]. Returned when ``lumped`` is false.
+            When ``lumped`` is true, this method currently returns ``None``.
+
+        Raises
+        ------
+        ValueError
+            If ``cost_raw`` has more than one dimension or has a one-dimensional
+            width other than one or the raw-material table width.
 
         """
 
@@ -922,13 +938,13 @@ class SimulationExec:
 
         duties, map_duties = self.GetDuties(full_output=True,
                                             **kwargs_items.get('duties', {}))
-        map_duties += 3
+        map_duties += 3  # [-], shift duty codes to cost-vector indices.
 
-        duty_unit_cost = np.zeros_like(map_duties, dtype=np.float64)
+        duty_unit_cost = np.zeros_like(map_duties, dtype=np.float64)  # [USD/GJ]
         for ind, row in enumerate(map_duties):
             duty_unit_cost[ind] = heat_exchange_cost[row]
 
-        duty_cost = np.abs(duties)*1e-9 * duty_unit_cost
+        duty_cost = np.abs(duties)*1e-9 * duty_unit_cost  # [USD]
 
         # ---------- Raw materials
         raw_kwargs = kwargs_items.get('raw_materials', {}).copy()
@@ -942,7 +958,7 @@ class SimulationExec:
             raise ValueError(
                 "cost_raw must be scalar or have one entry per raw-material "
                 "column")
-        raw_cost = cost_raw * raw_materials
+        raw_cost = cost_raw * raw_materials  # [USD]
 
         # ---------- Labor
         labor_cost = self.GetLabor(**kwargs_items.get('labor', {}))

--- a/PharmaPy/SimExec.py
+++ b/PharmaPy/SimExec.py
@@ -442,21 +442,7 @@ class SimulationExec:
             return cost_equip
 
     def GetLabor(self, wage=35, num_weeks=48):
-        """Estimate yearly labor cost by unit-operation class.
-
-        Parameters
-        ----------
-        wage : float, optional
-            Operator wage [USD/h].
-        num_weeks : int, optional
-            Operating weeks per year [week/yr].
-
-        Returns
-        -------
-        pandas.DataFrame
-            Labor classification columns [-] and labor cost [USD/yr].
-        """
-        # TODO: per/hour (per/shift) cost?
+        # TODO: clarify whether labor cost is hourly [1/h] or per shift [1/shift].
         has_solids = []
         is_batch = []
         uo_names = []

--- a/PharmaPy/SimExec.py
+++ b/PharmaPy/SimExec.py
@@ -442,6 +442,20 @@ class SimulationExec:
             return cost_equip
 
     def GetLabor(self, wage=35, num_weeks=48):
+        """Estimate yearly labor cost by unit-operation class.
+
+        Parameters
+        ----------
+        wage : float, optional
+            Operator wage [USD/h].
+        num_weeks : int, optional
+            Operating weeks per year [week/yr].
+
+        Returns
+        -------
+        pandas.DataFrame
+            Labor classification columns [-] and labor cost [USD/yr].
+        """
         # TODO: per/hour (per/shift) cost?
         has_solids = []
         is_batch = []
@@ -484,6 +498,22 @@ class SimulationExec:
         return labor_df
 
     def get_from_phases(self, phases, fields):
+        """Collect named attributes from one phase or a mixed phase.
+
+        Parameters
+        ----------
+        phases : object
+            PharmaPy phase or mixed-phase object.
+        fields : sequence of str
+            Attribute names to collect. Typical values include fractions [-],
+            temperature [K], pressure [Pa], amounts [kg] or [mol], and volumes
+            [m**3].
+
+        Returns
+        -------
+        dict
+            Attribute records keyed by phase object name.
+        """
         if phases.__module__ == 'PharmaPy.MixedPhases':
             phases = phases.Phases
         else:
@@ -499,6 +529,59 @@ class SimulationExec:
             out[name_phase] = phase_data
 
         return out
+
+    def get_dynamic_raw_inputs(self, inlet, stream, time):
+        """Evaluate dynamic raw-material inputs for one stream or phase.
+
+        Parameters
+        ----------
+        inlet : object
+            Raw inlet object. It may be a single stream or a mixed phase.
+        stream : object
+            Stream or phase currently being accounted.
+        time : ndarray
+            Simulation time grid [s].
+
+        Returns
+        -------
+        dict
+            Dynamic input profiles. Flow entries are [kg/s], [mol/s], or
+            [m**3/s] according to their key; temperature is [K].
+
+        Notes
+        -----
+        If a mixed phase owns a single dynamic inlet profile, the total dynamic
+        flow is split by each phase's steady flow fraction [-]. This preserves
+        the total mixed feed instead of integrating the full mixed profile once
+        for every phase.
+        """
+        if getattr(stream, 'DynamicInlet', None) is not None:
+            return stream.DynamicInlet.evaluate_inputs(time)
+
+        inputs = inlet.DynamicInlet.evaluate_inputs(time)
+        if stream is inlet:
+            return inputs
+
+        scaled = {}
+        flow_fields = ('mass_flow', 'mole_flow', 'vol_flow')
+        for field in flow_fields:
+            if field not in inputs:
+                continue
+
+            inlet_flow = getattr(inlet, field, 0)
+            stream_flow = getattr(stream, field, 0)
+            if inlet_flow == 0:
+                flow_fraction = 0
+            else:
+                flow_fraction = stream_flow / inlet_flow  # [-]
+
+            scaled[field] = inputs[field] * flow_fraction
+
+        for field in ('temp', 'pres'):
+            if field in inputs:
+                scaled[field] = inputs[field]
+
+        return scaled
 
     def get_raw_inlets(self, uo, basis='mass'):
         """Collect raw inlet data for a unit operation.
@@ -574,7 +657,8 @@ class SimulationExec:
                         total = stream.moles  # [mol]
                         stream_data[name_stream] = {'moles': total}
                         fields += ['mole_frac']
-                elif inlet.DynamicInlet is None:
+                elif (getattr(stream, 'DynamicInlet', None) is None and
+                      getattr(inlet, 'DynamicInlet', None) is None):
                     time = uo.result.time[-1] - uo.result.time[0]  # [s]
                     if basis == 'mass':
                         flow = stream.mass_flow  # [kg/s]
@@ -592,13 +676,13 @@ class SimulationExec:
 
                 else:
                     time = uo.result.time  # [s]
-                    inputs = inlet.DynamicInlet.evaluate_inputs(time)
+                    inputs = self.get_dynamic_raw_inputs(inlet, stream, time)
 
                     if basis == 'mass':
                         if 'mass_flow' in inputs:
                             flow = inputs['mass_flow']  # [kg/s]
                         else:
-                            flow = inputs['mole_flow'] * inlet.mw_av / 1000  # [kg/s]
+                            flow = inputs['mole_flow'] * stream.mw_av / 1000  # [kg/s]
 
                         total = trapezoidal_rule(time, flow)  # [kg]
 
@@ -610,7 +694,7 @@ class SimulationExec:
                         if 'mole_flow' in inputs:
                             flow = inputs['mole_flow']  # [mol/s]
                         else:
-                            flow = inputs['mass_flow'] / inlet.mw_av * 1000  # [mol/s]
+                            flow = inputs['mass_flow'] / stream.mw_av * 1000  # [mol/s]
 
                         total = trapezoidal_rule(time, flow)  # [mol]
 
@@ -812,6 +896,10 @@ class SimulationExec:
         ----------
         cost_raw : array_like
             Raw material unit costs compatible with the raw material table.
+            On a mass basis, values are [USD/kg]; on a mole basis, values are
+            [USD/mol]. A scalar applies to every raw-material column. A vector
+            must have one entry per raw-material column: the first entry prices
+            the total column and the remaining entries price per-species columns.
         include_holdups : bool, optional
             If true, raw material accounting includes initial holdups.
         steady_raw : bool, optional
@@ -827,8 +915,8 @@ class SimulationExec:
         Returns
         -------
         duty_cost, raw_cost, labor_cost : pandas.DataFrame
-            Operating-cost components for the solved flowsheet when ``lumped``
-            is false.
+            ``duty_cost`` [USD] and ``raw_cost`` [USD] are per simulated run.
+            ``labor_cost`` is [USD/yr]. Returned when ``lumped`` is false.
 
         """
 
@@ -862,6 +950,12 @@ class SimulationExec:
         raw_kwargs['include_holdups'] = include_holdups
 
         raw_materials = self.GetRawMaterials(**raw_kwargs)
+        if cost_raw.ndim > 1:
+            raise ValueError("cost_raw must be a scalar or a one-dimensional array")
+        if cost_raw.ndim == 1 and cost_raw.size not in (1, raw_materials.shape[1]):
+            raise ValueError(
+                "cost_raw must be scalar or have one entry per raw-material "
+                "column")
         raw_cost = cost_raw * raw_materials
 
         # ---------- Labor

--- a/PharmaPy/SimExec.py
+++ b/PharmaPy/SimExec.py
@@ -542,7 +542,7 @@ class SimulationExec:
             inlets = {'Inlet_%i' % num: obj for num, obj in enumerate(inlets)}
 
         raws = {key: val for key, val in inlets.items()
-                if val is not None and val.y_upstream is None}
+                if val is not None and val.y_upstream is None}  # raw inlets
 
         # inlets = [inlet for inlet in inlets
         #           if inlet is not None and inlet.y_upstream is None]
@@ -557,50 +557,50 @@ class SimulationExec:
 
             stream_data = {}
             for stream in streams:
-                fields = ['temp', 'pres']
+                fields = ['temp', 'pres']  # [K], [Pa]
 
                 name_stream = get_name_object(stream)
 
                 stream_data[name_stream] = {}
 
-                dens = stream.getDensity(basis=basis)
+                dens = stream.getDensity(basis=basis)  # [kg/m**3] or [mol/L]
 
                 if uo.oper_mode == 'Batch':
                     if basis == 'mass':
-                        total = stream.mass
+                        total = stream.mass  # [kg]
                         stream_data[name_stream] = {'mass': total}
                         fields += ['mass_frac']
                     elif basis == 'mole':
-                        total = stream.moles
+                        total = stream.moles  # [mol]
                         stream_data[name_stream] = {'moles': total}
                         fields += ['mole_frac']
                 elif inlet.DynamicInlet is None:
-                    time = uo.result.time[-1] - uo.result.time[0]
+                    time = uo.result.time[-1] - uo.result.time[0]  # [s]
                     if basis == 'mass':
-                        flow = stream.mass_flow
-                        total = flow*time
+                        flow = stream.mass_flow  # [kg/s]
+                        total = flow*time  # [kg]
 
                         stream_data[name_stream] = {'mass': total}
                         fields += ['mass_frac', 'mass_flow', 'vol_flow']
 
                     else:
-                        flow = stream.mole_flow
-                        total = flow*time
+                        flow = stream.mole_flow  # [mol/s]
+                        total = flow*time  # [mol]
 
                         stream_data[name_stream] = {'moles': total}
                         fields += ['mole_frac', 'mole_flow', 'vol_flow']
 
                 else:
-                    time = uo.result.time
+                    time = uo.result.time  # [s]
                     inputs = inlet.DynamicInlet.evaluate_inputs(time)
 
                     if basis == 'mass':
                         if 'mass_flow' in inputs:
-                            flow = inputs['mass_flow']
+                            flow = inputs['mass_flow']  # [kg/s]
                         else:
-                            flow = inputs['mole_flow'] * inlet.mw_av / 1000
+                            flow = inputs['mole_flow'] * inlet.mw_av / 1000  # [kg/s]
 
-                        total = trapezoidal_rule(time, flow)
+                        total = trapezoidal_rule(time, flow)  # [kg]
 
                         stream_data[name_stream] = {'mass': total}
 
@@ -608,20 +608,20 @@ class SimulationExec:
 
                     elif basis == 'mole':
                         if 'mole_flow' in inputs:
-                            flow = inputs['mole_flow']
+                            flow = inputs['mole_flow']  # [mol/s]
                         else:
-                            flow = inputs['mass_flow'] / inlet.mw_av * 1000
+                            flow = inputs['mass_flow'] / inlet.mw_av * 1000  # [mol/s]
 
-                        total = trapezoidal_rule(time, flow)
+                        total = trapezoidal_rule(time, flow)  # [mol]
 
                         stream_data[name_stream] = {'moles': total}
                         fields += ['mole_frac']
 
-                vol = total / dens
+                vol = total / dens  # [m**3] or [L]
                 if basis == 'mole':
-                    vol *= 1/1000
+                    vol *= 1/1000  # [m**3]
 
-                stream_data[name_stream]['vol'] = vol
+                stream_data[name_stream]['vol'] = vol  # [m**3]
 
             from_inlet = self.get_from_phases(inlet, fields)
 
@@ -633,6 +633,21 @@ class SimulationExec:
         return out
 
     def get_holdup(self, uo, basis='mass'):
+        """Collect initial holdup raw-material records.
+
+        Parameters
+        ----------
+        uo : object
+            Unit operation that may retain an original phase or mixed phase.
+        basis : {'mass', 'mole'}, optional
+            Accounting basis. Mass holdups are [kg]; molar holdups are [mol].
+
+        Returns
+        -------
+        dict
+            Initial holdup records including composition fractions [-],
+            temperature [K], pressure [Pa], and volume [m**3].
+        """
         out = {}
 
         if hasattr(uo, '__original_phase__'):
@@ -653,14 +668,13 @@ class SimulationExec:
 
     def GetRawMaterials(self, basis='mass', totals=True, steady_state=False,
                         include_holdups=True):
-        """
-        Get raw material use for all solved unit operations.
+        """Get raw material use for all solved unit operations.
 
         Parameters
         ----------
         basis : {'mass', 'mole'}, optional
-            Accounting basis. Mass totals are reported in kg and molar totals
-            are reported in mol.
+            Accounting basis. Mass totals are reported in [kg] and molar
+            totals are reported in [mol].
         totals : bool, optional
             If true, aggregate each raw stream into total and per-species
             columns on the selected basis.
@@ -674,7 +688,8 @@ class SimulationExec:
         -------
         raw_df : pandas.DataFrame
             Raw material table indexed by unit operation, raw source, and
-            stream or phase name.
+            stream or phase name. Total columns are [kg] or [mol], and
+            per-species columns use the same selected basis.
 
         """
         if basis not in ('mass', 'mole'):
@@ -719,10 +734,10 @@ class SimulationExec:
 
             if totals:
                 if basis == 'mass':
-                    mass_frac = raw_df.filter(regex='mass_frac').values
+                    mass_frac = raw_df.filter(regex='mass_frac').values  # [-]
 
-                    mass = raw_df['mass'].values[:, np.newaxis]
-                    mass_comp = mass_frac * mass
+                    mass = raw_df['mass'].values[:, np.newaxis]  # [kg]
+                    mass_comp = mass_frac * mass  # [kg]
 
                     cols = ['mass_%s' % comp for comp in self.NamesSpecies]
                     cols = ['mass'] + cols
@@ -731,9 +746,9 @@ class SimulationExec:
                                           columns=cols, index=raw_df.index)
 
                 elif basis == 'mole':
-                    mole_frac = raw_df.filter(regex='mole_frac').values
-                    moles = raw_df['moles'].values[:, np.newaxis]
-                    moles_comp = mole_frac * moles
+                    mole_frac = raw_df.filter(regex='mole_frac').values  # [-]
+                    moles = raw_df['moles'].values[:, np.newaxis]  # [mol]
+                    moles_comp = mole_frac * moles  # [mol]
 
                     cols = ['moles_%s' % comp for comp in self.NamesSpecies]
                     cols = ['moles'] + cols

--- a/PharmaPy/SimExec.py
+++ b/PharmaPy/SimExec.py
@@ -473,7 +473,7 @@ class SimulationExec:
         num_workers = has_solids * (2 + is_batch) + ~has_solids * (1 + is_batch)
 
         hr_week = 40
-        labor_cost = 1.20 * num_workers * 5 * (hr_week * num_weeks) * wage  # USD/yr
+        labor_cost = 1.20 * num_workers * 5 * (hr_week * num_weeks) * wage  # [USD/yr]
 
         labor_array = np.column_stack(
             (has_solids, is_batch, num_workers, labor_cost))
@@ -491,16 +491,40 @@ class SimulationExec:
 
         out = {}
         for phase in phases:
-            di = {}
+            phase_data = {}
             for field in fields:
-                di[field] = getattr(phase, field)
+                phase_data[field] = getattr(phase, field)
 
             name_phase = get_name_object(phase)
-            out[name_phase] = di
+            out[name_phase] = phase_data
 
         return out
 
     def get_raw_inlets(self, uo, basis='mass'):
+        """Collect raw inlet data for a unit operation.
+
+        Parameters
+        ----------
+        uo : object
+            Unit operation whose upstream-free inlet streams are treated as raw
+            materials.
+        basis : {'mass', 'mole'}, optional
+            Accounting basis. Mass totals are reported in [kg] and mass-flow
+            rates in [kg/s]; molar totals are reported in [mol] and molar-flow
+            rates in [mol/s].
+
+        Returns
+        -------
+        dict
+            Raw inlet records keyed first by inlet name and then by stream or
+            phase name. Records include totals, composition fractions [-],
+            temperature [K], pressure [Pa], and volume [m**3].
+
+        Raises
+        ------
+        ValueError
+            If ``basis`` is not ``'mass'`` or ``'mole'``.
+        """
         if basis not in ('mass', 'mole'):
             raise ValueError("basis must be either 'mass' or 'mole'")
 
@@ -531,24 +555,24 @@ class SimulationExec:
             else:
                 streams = [inlet]
 
-            di = {}
+            stream_data = {}
             for stream in streams:
                 fields = ['temp', 'pres']
 
                 name_stream = get_name_object(stream)
 
-                di[name_stream] = {}
+                stream_data[name_stream] = {}
 
                 dens = stream.getDensity(basis=basis)
 
                 if uo.oper_mode == 'Batch':
                     if basis == 'mass':
                         total = stream.mass
-                        di[name_stream] = {'mass': total}
+                        stream_data[name_stream] = {'mass': total}
                         fields += ['mass_frac']
                     elif basis == 'mole':
                         total = stream.moles
-                        di[name_stream] = {'moles': total}
+                        stream_data[name_stream] = {'moles': total}
                         fields += ['mole_frac']
                 elif inlet.DynamicInlet is None:
                     time = uo.result.time[-1] - uo.result.time[0]
@@ -556,14 +580,14 @@ class SimulationExec:
                         flow = stream.mass_flow
                         total = flow*time
 
-                        di[name_stream] = {'mass': total}
+                        stream_data[name_stream] = {'mass': total}
                         fields += ['mass_frac', 'mass_flow', 'vol_flow']
 
                     else:
                         flow = stream.mole_flow
                         total = flow*time
 
-                        di[name_stream] = {'moles': total}
+                        stream_data[name_stream] = {'moles': total}
                         fields += ['mole_frac', 'mole_flow', 'vol_flow']
 
                 else:
@@ -578,7 +602,7 @@ class SimulationExec:
 
                         total = trapezoidal_rule(time, flow)
 
-                        di[name_stream] = {'mass': total}
+                        stream_data[name_stream] = {'mass': total}
 
                         fields += ['mass_frac']
 
@@ -590,21 +614,21 @@ class SimulationExec:
 
                         total = trapezoidal_rule(time, flow)
 
-                        di[name_stream] = {'moles': total}
+                        stream_data[name_stream] = {'moles': total}
                         fields += ['mole_frac']
 
                 vol = total / dens
                 if basis == 'mole':
                     vol *= 1/1000
 
-                di[name_stream]['vol'] = vol
+                stream_data[name_stream]['vol'] = vol
 
             from_inlet = self.get_from_phases(inlet, fields)
 
             for key in from_inlet:
-                di[key].update(from_inlet[key])
+                stream_data[key].update(from_inlet[key])
 
-            out[name] = di
+            out[name] = stream_data
 
         return out
 
@@ -800,7 +824,7 @@ class SimulationExec:
         cost_raw = np.asarray(cost_raw)
 
         # ---------- Heat duties
-        # Energy cost (USD/GJ)
+        # Energy cost [USD/GJ].
         heat_exchange_cost = [14.12, 8.49, 4.77,  # refrigeration
                               0.378,  # water
                               4.54, 4.77, 5.66]  # steam

--- a/PharmaPy/SimExec.py
+++ b/PharmaPy/SimExec.py
@@ -781,7 +781,9 @@ class SimulationExec:
             Reserved for lumped OPEX reporting.
         kwargs_items : dict, optional
             Per-item keyword arguments for ``duties``, ``raw_materials``, and
-            ``labor`` calculations.
+            ``labor`` calculations. Top-level ``steady_raw`` and
+            ``include_holdups`` take precedence over same-named entries in
+            ``kwargs_items['raw_materials']``.
 
         Returns
         -------

--- a/tests/test_simexec_raw_materials.py
+++ b/tests/test_simexec_raw_materials.py
@@ -9,7 +9,48 @@ pytestmark = pytest.mark.unit
 
 class _Result:
     def __init__(self, time):
-        self.time = np.asarray(time, dtype=float)
+        """Create a minimal result object.
+
+        Parameters
+        ----------
+        time : array_like
+            Simulation time grid [s].
+        """
+        self.time = np.asarray(time, dtype=float)  # [s]
+
+
+class _DynamicInput:
+    def __init__(self, **profiles):
+        """Create a deterministic dynamic-input test double.
+
+        Parameters
+        ----------
+        **profiles
+            Dynamic profile values. Flow entries are [kg/s], [mol/s], or
+            [m**3/s] according to key; temperature values are [K].
+        """
+        self.profiles = profiles
+
+    def evaluate_inputs(self, time):
+        """Return dynamic raw-inlet profiles on the requested time grid.
+
+        Parameters
+        ----------
+        time : ndarray
+            Simulation time grid [s].
+
+        Returns
+        -------
+        dict
+            Flow profiles [kg/s], [mol/s], or [m**3/s] according to key.
+        """
+        out = {}
+        for key, value in self.profiles.items():
+            if np.ndim(value) == 0:
+                out[key] = np.ones_like(time, dtype=float) * value
+            else:
+                out[key] = np.asarray(value, dtype=float)
+        return out
 
 
 class _RawPhase:
@@ -68,11 +109,20 @@ class _UnitOperation:
     __module__ = "PharmaPy.Containers"
 
     def __init__(self, inlet=None, time=(0.0, 10.0)):
+        """Create a minimal solved unit operation.
+
+        Parameters
+        ----------
+        inlet : object, optional
+            Raw inlet or mixed inlet used by raw-material accounting.
+        time : tuple of float, optional
+            Simulated start and end times [s].
+        """
         self.Inlet = inlet
         self.oper_mode = "Continuous"
         self.result = _Result(time)
         self.heat_duty = np.array([0.0, 0.0])  # [J]
-        self.duty_type = np.array([0, 0], dtype=int)
+        self.duty_type = np.array([0, 0], dtype=int)  # [-]
         self.outputs = {}
 
 
@@ -84,6 +134,7 @@ def _sim_with_unit(unit):
 
 
 def test_get_opex_passes_raw_material_keywords_and_holdup_flag():
+    """Top-level raw-material flags take precedence in OPEX accounting."""
     inlet = _RawPhase(mass_flow=2.0, mass_frac=(0.25, 0.75))
     initial_holdup = _RawPhase(mass=5.0, mass_frac=(0.4, 0.6))
     unit = _UnitOperation(inlet)
@@ -105,6 +156,7 @@ def test_get_opex_passes_raw_material_keywords_and_holdup_flag():
 
 
 def test_get_opex_includes_initial_holdup_by_default():
+    """OPEX includes initial holdup raw material unless disabled."""
     inlet = _RawPhase(mass_flow=2.0, mass_frac=(0.25, 0.75))
     initial_holdup = _RawPhase(mass=5.0, mass_frac=(0.4, 0.6))
     unit = _UnitOperation(inlet)
@@ -126,6 +178,7 @@ def test_get_opex_includes_initial_holdup_by_default():
 
 
 def test_mole_basis_totals_use_canonical_singular_basis():
+    """Mole-basis totals use the singular ``basis='mole'`` path."""
     inlet = _RawPhase(mole_flow=4.0, mole_frac=(0.25, 0.75))
     sim = _sim_with_unit(_UnitOperation(inlet))
 
@@ -139,6 +192,7 @@ def test_mole_basis_totals_use_canonical_singular_basis():
 
 
 def test_batch_raw_inlet_records_total_before_aggregation():
+    """Batch raw inlets record total material before species aggregation."""
     inlet = _RawPhase(mass=6.0, mass_frac=(0.2, 0.8))
     unit = _UnitOperation(inlet)
     unit.oper_mode = "Batch"
@@ -154,6 +208,7 @@ def test_batch_raw_inlet_records_total_before_aggregation():
 
 
 def test_mixed_phase_raw_inlet_is_decomposed_by_phase():
+    """Static mixed raw inlets account each phase once."""
     liquid = _RawPhase(mass_flow=1.0, mass_frac=(0.8, 0.2))
     solid = _RawPhase(mass_flow=3.0, mass_frac=(0.1, 0.9))
     mixed = _MixedRawInlet([liquid, solid])
@@ -166,3 +221,50 @@ def test_mixed_phase_raw_inlet_is_decomposed_by_phase():
         np.sort(raw_materials["mass"].to_numpy()),
         [10.0, 30.0],
     )
+
+
+def test_dynamic_mixed_phase_raw_inlet_splits_total_flow_by_phase():
+    """Dynamic mixed raw inlets do not integrate the total flow per phase."""
+    liquid = _RawPhase(mass_flow=1.0, mass_frac=(0.8, 0.2))
+    solid = _RawPhase(mass_flow=3.0, mass_frac=(0.1, 0.9))
+    mixed = _MixedRawInlet([liquid, solid])
+    mixed.DynamicInlet = _DynamicInput(mass_flow=4.0)  # [kg/s]
+    sim = _sim_with_unit(_UnitOperation(mixed))
+
+    raw_materials = sim.GetRawMaterials(basis="mass", totals=False)
+
+    assert len(raw_materials) == 2
+    np.testing.assert_allclose(
+        np.sort(raw_materials["mass"].to_numpy()),
+        [10.0, 30.0],
+    )
+
+
+def test_get_opex_applies_nonunity_raw_cost_vector():
+    """Vector raw costs price total and species columns explicitly."""
+    inlet = _RawPhase(mass_flow=2.0, mass_frac=(0.25, 0.75))
+    sim = _sim_with_unit(_UnitOperation(inlet))
+
+    _, raw_cost, _ = sim.GetOPEX(
+        np.array([0.0, 2.0, 3.0]),  # [USD/kg]
+        include_holdups=False,
+        kwargs_items={"raw_materials": {"basis": "mass"}},
+    )
+
+    np.testing.assert_allclose(
+        raw_cost.iloc[0][["mass", "mass_A", "mass_B"]],
+        [0.0, 10.0, 45.0],  # [USD]
+    )
+
+
+def test_get_opex_rejects_raw_cost_vector_with_wrong_width():
+    """Raw cost vectors must match the raw-material table width."""
+    inlet = _RawPhase(mass_flow=2.0, mass_frac=(0.25, 0.75))
+    sim = _sim_with_unit(_UnitOperation(inlet))
+
+    with pytest.raises(ValueError, match="one entry per raw-material column"):
+        sim.GetOPEX(
+            np.array([1.0, 2.0]),  # [USD/kg]
+            include_holdups=False,
+            kwargs_items={"raw_materials": {"basis": "mass"}},
+        )

--- a/tests/test_simexec_raw_materials.py
+++ b/tests/test_simexec_raw_materials.py
@@ -22,20 +22,20 @@ class _RawPhase:
             density_mass=1000.0, density_mole=40.0):
         self.y_upstream = None
         self.DynamicInlet = None
-        self.mass_flow = mass_flow  # kg/s
-        self.mole_flow = mole_flow  # mol/s
-        self.mass = mass  # kg
-        self.moles = moles  # mol
+        self.mass_flow = mass_flow  # [kg/s]
+        self.mole_flow = mole_flow  # [mol/s]
+        self.mass = mass  # [kg]
+        self.moles = moles  # [mol]
         self.mass_frac = np.asarray(mass_frac, dtype=float)  # [-]
         self.mole_frac = np.asarray(mole_frac, dtype=float)  # [-]
-        self.vol_flow = mass_flow / density_mass  # m**3/s
-        self.vol = mass / density_mass if density_mass else 0.0  # m**3
-        self.temp = 300.0  # K
-        self.pres = 101325.0  # Pa
-        self.mw_av = 50.0  # g/mol
+        self.vol_flow = mass_flow / density_mass  # [m**3/s]
+        self.vol = mass / density_mass if density_mass else 0.0  # [m**3]
+        self.temp = 300.0  # [K]
+        self.pres = 101325.0  # [Pa]
+        self.mw_av = 50.0  # [g/mol]
         self.transferred_from_uo = False
-        self._density_mass = density_mass  # kg/m**3
-        self._density_mole = density_mole  # mol/L
+        self._density_mass = density_mass  # [kg/m**3]
+        self._density_mole = density_mole  # [mol/L]
 
     def getDensity(self, basis="mass", **kwargs):
         if basis == "mass":
@@ -50,14 +50,14 @@ class _MixedRawInlet:
         self.Phases = list(phases)
         self.y_upstream = None
         self.DynamicInlet = None
-        self.mass_flow = sum(phase.mass_flow for phase in phases)  # kg/s
-        self.mole_flow = sum(phase.mole_flow for phase in phases)  # mol/s
+        self.mass_flow = sum(phase.mass_flow for phase in phases)  # [kg/s]
+        self.mole_flow = sum(phase.mole_flow for phase in phases)  # [mol/s]
         self.mass_frac = np.array([0.5, 0.5], dtype=float)  # [-]
         self.mole_frac = np.array([0.5, 0.5], dtype=float)  # [-]
-        self.vol_flow = sum(phase.vol_flow for phase in phases)  # m**3/s
-        self.temp = 300.0  # K
-        self.pres = 101325.0  # Pa
-        self.mw_av = 50.0  # g/mol
+        self.vol_flow = sum(phase.vol_flow for phase in phases)  # [m**3/s]
+        self.temp = 300.0  # [K]
+        self.pres = 101325.0  # [Pa]
+        self.mw_av = 50.0  # [g/mol]
         self.transferred_from_uo = False
 
     def getDensity(self, basis="mass", **kwargs):
@@ -71,7 +71,7 @@ class _UnitOperation:
         self.Inlet = inlet
         self.oper_mode = "Continuous"
         self.result = _Result(time)
-        self.heat_duty = np.array([0.0, 0.0])  # J
+        self.heat_duty = np.array([0.0, 0.0])  # [J]
         self.duty_type = np.array([0, 0], dtype=int)
         self.outputs = {}
 

--- a/tests/test_simexec_raw_materials.py
+++ b/tests/test_simexec_raw_materials.py
@@ -104,6 +104,27 @@ def test_get_opex_passes_raw_material_keywords_and_holdup_flag():
     )
 
 
+def test_get_opex_includes_initial_holdup_by_default():
+    inlet = _RawPhase(mass_flow=2.0, mass_frac=(0.25, 0.75))
+    initial_holdup = _RawPhase(mass=5.0, mass_frac=(0.4, 0.6))
+    unit = _UnitOperation(inlet)
+    unit.__original_phase__ = initial_holdup
+    sim = _sim_with_unit(unit)
+
+    _, raw_cost, _ = sim.GetOPEX(
+        1.0,
+        kwargs_items={"raw_materials": {"basis": "mass"}},
+    )
+
+    holdup_cost = raw_cost.xs("Initial_holdup", level=1)
+
+    assert len(holdup_cost) == 1
+    np.testing.assert_allclose(
+        holdup_cost.iloc[0][["mass", "mass_A", "mass_B"]],
+        [5.0, 2.0, 3.0],
+    )
+
+
 def test_mole_basis_totals_use_canonical_singular_basis():
     inlet = _RawPhase(mole_flow=4.0, mole_frac=(0.25, 0.75))
     sim = _sim_with_unit(_UnitOperation(inlet))

--- a/tests/test_simexec_raw_materials.py
+++ b/tests/test_simexec_raw_materials.py
@@ -1,3 +1,5 @@
+"""Regression tests for raw-material accounting in ``SimulationExec``."""
+
 import numpy as np
 import pytest
 
@@ -8,6 +10,8 @@ pytestmark = pytest.mark.unit
 
 
 class _Result:
+    """Minimal solved-result test double."""
+
     def __init__(self, time):
         """Create a minimal result object.
 
@@ -20,6 +24,8 @@ class _Result:
 
 
 class _DynamicInput:
+    """Deterministic dynamic-input profile test double."""
+
     def __init__(self, **profiles):
         """Create a deterministic dynamic-input test double.
 
@@ -27,7 +33,8 @@ class _DynamicInput:
         ----------
         **profiles
             Dynamic profile values. Flow entries are [kg/s], [mol/s], or
-            [m**3/s] according to key; temperature values are [K].
+            [m**3/s] according to key; temperature values are [K] and pressure
+            values are [Pa].
         """
         self.profiles = profiles
 
@@ -42,7 +49,8 @@ class _DynamicInput:
         Returns
         -------
         dict
-            Flow profiles [kg/s], [mol/s], or [m**3/s] according to key.
+            Flow profiles [kg/s], [mol/s], or [m**3/s] according to key;
+            temperature profiles are [K] and pressure profiles are [Pa].
         """
         out = {}
         for key, value in self.profiles.items():
@@ -54,6 +62,8 @@ class _DynamicInput:
 
 
 class _RawPhase:
+    """Single-phase raw inlet test double."""
+
     __module__ = "PharmaPy.Phases"
 
     def __init__(
@@ -61,6 +71,27 @@ class _RawPhase:
             mass=0.0, moles=0.0,
             mass_frac=(1.0, 0.0), mole_frac=(1.0, 0.0),
             density_mass=1000.0, density_mole=40.0):
+        """Create a single-phase raw inlet.
+
+        Parameters
+        ----------
+        mass_flow : float, optional
+            Static mass flow [kg/s].
+        mole_flow : float, optional
+            Static molar flow [mol/s].
+        mass : float, optional
+            Batch mass or initial holdup mass [kg].
+        moles : float, optional
+            Batch molar amount or initial holdup amount [mol].
+        mass_frac : tuple of float, optional
+            Component mass fractions [-].
+        mole_frac : tuple of float, optional
+            Component mole fractions [-].
+        density_mass : float, optional
+            Mass density [kg/m**3].
+        density_mole : float, optional
+            Molar density [mol/L].
+        """
         self.y_upstream = None
         self.DynamicInlet = None
         self.mass_flow = mass_flow  # [kg/s]
@@ -79,15 +110,38 @@ class _RawPhase:
         self._density_mole = density_mole  # [mol/L]
 
     def getDensity(self, basis="mass", **kwargs):
+        """Return the test density on the requested accounting basis.
+
+        Parameters
+        ----------
+        basis : {'mass', 'mole'}, optional
+            Density basis.
+        **kwargs
+            Ignored compatibility arguments.
+
+        Returns
+        -------
+        float
+            Mass density [kg/m**3] or molar density [mol/L].
+        """
         if basis == "mass":
             return self._density_mass
         return self._density_mole
 
 
 class _MixedRawInlet:
+    """Mixed-phase raw inlet test double."""
+
     __module__ = "PharmaPy.MixedPhases"
 
     def __init__(self, phases):
+        """Create a mixed inlet from phase test doubles.
+
+        Parameters
+        ----------
+        phases : sequence of _RawPhase
+            Component phases with flows [kg/s] and [mol/s].
+        """
         self.Phases = list(phases)
         self.y_upstream = None
         self.DynamicInlet = None
@@ -102,10 +156,26 @@ class _MixedRawInlet:
         self.transferred_from_uo = False
 
     def getDensity(self, basis="mass", **kwargs):
+        """Return the aggregate density for compatibility.
+
+        Parameters
+        ----------
+        basis : {'mass', 'mole'}, optional
+            Density basis.
+        **kwargs
+            Ignored compatibility arguments.
+
+        Returns
+        -------
+        float
+            Mass density [kg/m**3] or molar density [mol/L].
+        """
         return 1000.0 if basis == "mass" else 40.0
 
 
 class _UnitOperation:
+    """Minimal unit-operation test double."""
+
     __module__ = "PharmaPy.Containers"
 
     def __init__(self, inlet=None, time=(0.0, 10.0)):
@@ -127,6 +197,18 @@ class _UnitOperation:
 
 
 def _sim_with_unit(unit):
+    """Build a ``SimulationExec`` instance around one unit operation.
+
+    Parameters
+    ----------
+    unit : object
+        Unit operation test double.
+
+    Returns
+    -------
+    SimulationExec
+        Simulation executor with species names [-] and one unit operation.
+    """
     sim = object.__new__(SimulationExec)
     sim.NamesSpecies = ["A", "B"]
     sim.uos_instances = {"U01": unit}
@@ -142,16 +224,18 @@ def test_get_opex_passes_raw_material_keywords_and_holdup_flag():
     sim = _sim_with_unit(unit)
 
     _, raw_cost, _ = sim.GetOPEX(
-        1.0,
+        1.0,  # [USD/kg]
         include_holdups=False,
         kwargs_items={"raw_materials": {"basis": "mass"}},
     )
+
+    expected_cost = [20.0, 5.0, 15.0]  # [USD], 2 kg/s over 10 s.
 
     assert "Initial_holdup" not in raw_cost.index.get_level_values(1)
     assert list(raw_cost.columns) == ["mass", "mass_A", "mass_B"]
     np.testing.assert_allclose(
         raw_cost.iloc[0][["mass", "mass_A", "mass_B"]],
-        [20.0, 5.0, 15.0],
+        expected_cost,
     )
 
 
@@ -164,16 +248,17 @@ def test_get_opex_includes_initial_holdup_by_default():
     sim = _sim_with_unit(unit)
 
     _, raw_cost, _ = sim.GetOPEX(
-        1.0,
+        1.0,  # [USD/kg]
         kwargs_items={"raw_materials": {"basis": "mass"}},
     )
 
     holdup_cost = raw_cost.xs("Initial_holdup", level=1)
+    expected_holdup_cost = [5.0, 2.0, 3.0]  # [USD], 5 kg at 0.4/0.6.
 
     assert len(holdup_cost) == 1
     np.testing.assert_allclose(
         holdup_cost.iloc[0][["mass", "mass_A", "mass_B"]],
-        [5.0, 2.0, 3.0],
+        expected_holdup_cost,
     )
 
 
@@ -183,11 +268,12 @@ def test_mole_basis_totals_use_canonical_singular_basis():
     sim = _sim_with_unit(_UnitOperation(inlet))
 
     raw_materials = sim.GetRawMaterials(basis="mole")
+    expected_moles = [40.0, 10.0, 30.0]  # [mol], 4 mol/s over 10 s.
 
     assert list(raw_materials.columns) == ["moles", "moles_A", "moles_B"]
     np.testing.assert_allclose(
         raw_materials.iloc[0][["moles", "moles_A", "moles_B"]],
-        [40.0, 10.0, 30.0],
+        expected_moles,
     )
 
 
@@ -199,11 +285,12 @@ def test_batch_raw_inlet_records_total_before_aggregation():
     sim = _sim_with_unit(unit)
 
     raw_materials = sim.GetRawMaterials(basis="mass")
+    expected_mass = [6.0, 1.2, 4.8]  # [kg], 6 kg at 0.2/0.8.
 
     assert list(raw_materials.columns) == ["mass", "mass_A", "mass_B"]
     np.testing.assert_allclose(
         raw_materials.iloc[0][["mass", "mass_A", "mass_B"]],
-        [6.0, 1.2, 4.8],
+        expected_mass,
     )
 
 
@@ -215,11 +302,12 @@ def test_mixed_phase_raw_inlet_is_decomposed_by_phase():
     sim = _sim_with_unit(_UnitOperation(mixed))
 
     raw_materials = sim.GetRawMaterials(basis="mass", totals=False)
+    expected_phase_mass = [10.0, 30.0]  # [kg], phase flows over 10 s.
 
     assert len(raw_materials) == 2
     np.testing.assert_allclose(
         np.sort(raw_materials["mass"].to_numpy()),
-        [10.0, 30.0],
+        expected_phase_mass,
     )
 
 
@@ -232,11 +320,12 @@ def test_dynamic_mixed_phase_raw_inlet_splits_total_flow_by_phase():
     sim = _sim_with_unit(_UnitOperation(mixed))
 
     raw_materials = sim.GetRawMaterials(basis="mass", totals=False)
+    expected_phase_mass = [10.0, 30.0]  # [kg], 4 kg/s split 0.25/0.75.
 
     assert len(raw_materials) == 2
     np.testing.assert_allclose(
         np.sort(raw_materials["mass"].to_numpy()),
-        [10.0, 30.0],
+        expected_phase_mass,
     )
 
 
@@ -251,9 +340,11 @@ def test_get_opex_applies_nonunity_raw_cost_vector():
         kwargs_items={"raw_materials": {"basis": "mass"}},
     )
 
+    expected_cost = [0.0, 10.0, 45.0]  # [USD], zero total-price column.
+
     np.testing.assert_allclose(
         raw_cost.iloc[0][["mass", "mass_A", "mass_B"]],
-        [0.0, 10.0, 45.0],  # [USD]
+        expected_cost,
     )
 
 

--- a/tests/test_simexec_raw_materials.py
+++ b/tests/test_simexec_raw_materials.py
@@ -1,0 +1,147 @@
+import numpy as np
+import pytest
+
+from PharmaPy.SimExec import SimulationExec
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Result:
+    def __init__(self, time):
+        self.time = np.asarray(time, dtype=float)
+
+
+class _RawPhase:
+    __module__ = "PharmaPy.Phases"
+
+    def __init__(
+            self, mass_flow=0.0, mole_flow=0.0,
+            mass=0.0, moles=0.0,
+            mass_frac=(1.0, 0.0), mole_frac=(1.0, 0.0),
+            density_mass=1000.0, density_mole=40.0):
+        self.y_upstream = None
+        self.DynamicInlet = None
+        self.mass_flow = mass_flow  # kg/s
+        self.mole_flow = mole_flow  # mol/s
+        self.mass = mass  # kg
+        self.moles = moles  # mol
+        self.mass_frac = np.asarray(mass_frac, dtype=float)  # [-]
+        self.mole_frac = np.asarray(mole_frac, dtype=float)  # [-]
+        self.vol_flow = mass_flow / density_mass  # m**3/s
+        self.vol = mass / density_mass if density_mass else 0.0  # m**3
+        self.temp = 300.0  # K
+        self.pres = 101325.0  # Pa
+        self.mw_av = 50.0  # g/mol
+        self.transferred_from_uo = False
+        self._density_mass = density_mass  # kg/m**3
+        self._density_mole = density_mole  # mol/L
+
+    def getDensity(self, basis="mass", **kwargs):
+        if basis == "mass":
+            return self._density_mass
+        return self._density_mole
+
+
+class _MixedRawInlet:
+    __module__ = "PharmaPy.MixedPhases"
+
+    def __init__(self, phases):
+        self.Phases = list(phases)
+        self.y_upstream = None
+        self.DynamicInlet = None
+        self.mass_flow = sum(phase.mass_flow for phase in phases)  # kg/s
+        self.mole_flow = sum(phase.mole_flow for phase in phases)  # mol/s
+        self.mass_frac = np.array([0.5, 0.5], dtype=float)  # [-]
+        self.mole_frac = np.array([0.5, 0.5], dtype=float)  # [-]
+        self.vol_flow = sum(phase.vol_flow for phase in phases)  # m**3/s
+        self.temp = 300.0  # K
+        self.pres = 101325.0  # Pa
+        self.mw_av = 50.0  # g/mol
+        self.transferred_from_uo = False
+
+    def getDensity(self, basis="mass", **kwargs):
+        return 1000.0 if basis == "mass" else 40.0
+
+
+class _UnitOperation:
+    __module__ = "PharmaPy.Containers"
+
+    def __init__(self, inlet=None, time=(0.0, 10.0)):
+        self.Inlet = inlet
+        self.oper_mode = "Continuous"
+        self.result = _Result(time)
+        self.heat_duty = np.array([0.0, 0.0])  # J
+        self.duty_type = np.array([0, 0], dtype=int)
+        self.outputs = {}
+
+
+def _sim_with_unit(unit):
+    sim = object.__new__(SimulationExec)
+    sim.NamesSpecies = ["A", "B"]
+    sim.uos_instances = {"U01": unit}
+    return sim
+
+
+def test_get_opex_passes_raw_material_keywords_and_holdup_flag():
+    inlet = _RawPhase(mass_flow=2.0, mass_frac=(0.25, 0.75))
+    initial_holdup = _RawPhase(mass=5.0, mass_frac=(0.4, 0.6))
+    unit = _UnitOperation(inlet)
+    unit.__original_phase__ = initial_holdup
+    sim = _sim_with_unit(unit)
+
+    _, raw_cost, _ = sim.GetOPEX(
+        1.0,
+        include_holdups=False,
+        kwargs_items={"raw_materials": {"basis": "mass"}},
+    )
+
+    assert "Initial_holdup" not in raw_cost.index.get_level_values(1)
+    assert list(raw_cost.columns) == ["mass", "mass_A", "mass_B"]
+    np.testing.assert_allclose(
+        raw_cost.iloc[0][["mass", "mass_A", "mass_B"]],
+        [20.0, 5.0, 15.0],
+    )
+
+
+def test_mole_basis_totals_use_canonical_singular_basis():
+    inlet = _RawPhase(mole_flow=4.0, mole_frac=(0.25, 0.75))
+    sim = _sim_with_unit(_UnitOperation(inlet))
+
+    raw_materials = sim.GetRawMaterials(basis="mole")
+
+    assert list(raw_materials.columns) == ["moles", "moles_A", "moles_B"]
+    np.testing.assert_allclose(
+        raw_materials.iloc[0][["moles", "moles_A", "moles_B"]],
+        [40.0, 10.0, 30.0],
+    )
+
+
+def test_batch_raw_inlet_records_total_before_aggregation():
+    inlet = _RawPhase(mass=6.0, mass_frac=(0.2, 0.8))
+    unit = _UnitOperation(inlet)
+    unit.oper_mode = "Batch"
+    sim = _sim_with_unit(unit)
+
+    raw_materials = sim.GetRawMaterials(basis="mass")
+
+    assert list(raw_materials.columns) == ["mass", "mass_A", "mass_B"]
+    np.testing.assert_allclose(
+        raw_materials.iloc[0][["mass", "mass_A", "mass_B"]],
+        [6.0, 1.2, 4.8],
+    )
+
+
+def test_mixed_phase_raw_inlet_is_decomposed_by_phase():
+    liquid = _RawPhase(mass_flow=1.0, mass_frac=(0.8, 0.2))
+    solid = _RawPhase(mass_flow=3.0, mass_frac=(0.1, 0.9))
+    mixed = _MixedRawInlet([liquid, solid])
+    sim = _sim_with_unit(_UnitOperation(mixed))
+
+    raw_materials = sim.GetRawMaterials(basis="mass", totals=False)
+
+    assert len(raw_materials) == 2
+    np.testing.assert_allclose(
+        np.sort(raw_materials["mass"].to_numpy()),
+        [10.0, 30.0],
+    )


### PR DESCRIPTION
## Summary

- Fix `GetOPEX` so raw-material accounting options are passed to `GetRawMaterials` by keyword instead of shifting booleans into `basis` and `totals`.
- Add `include_holdups` support to `GetRawMaterials`, preserve the existing `basis, totals, steady_state` positional order, and document the raw-material/OPEX APIs.
- Fix molar totals to use the canonical `basis="mole"` branch.
- Split mixed-phase raw inlets by `__module__ == "PharmaPy.MixedPhases"` and use each phase stream's own static flow for phase-specific totals.
- Add focused unit regressions for OPEX forwarding, molar aggregation, batch raw totals, and mixed-phase raw inlet decomposition.

Closes #76.

Related issue map: #19 and #57 are mentioned in the issue as related but not duplicates; this PR does not change their stream-handoff or solvent-index behavior.

Follow-up issue map: #127 covers labor-cost documentation, #128 covers `SimExec.py` cost-constant references, and #129 covers the broader pre-existing `SimExec` documentation/unit audit outside this PR.

## Acceptance Criteria

- [x] `GetOPEX(cost_raw, ...)` no longer passes `include_holdups` and `steady_raw` as positional `GetRawMaterials` arguments.
- [x] `GetRawMaterials(basis="mole")` builds `moles` and per-species `moles_<species>` totals.
- [x] Mixed-phase raw inlets are decomposed into their component phases without the previous merge `KeyError`.
- [x] Batch raw inlets record basis totals before aggregation.

## Branch Hygiene

- Base branch: `master`
- Source branch point: `c7a38a412d1ab26c8d91ef975ff4a5b3a7393c3b`
- Stacked status: not stacked
- Open PR overlap: none found for `PharmaPy/SimExec.py` or `tests/test_simexec_raw_materials.py`

## Validation

- Red check: the initial regression test file failed against unchanged `SimExec.py` with the expected OPEX positional-argument, molar-total, and mixed-phase `KeyError` failures.
- `python -m pytest tests/test_simexec_raw_materials.py tests/test_simexec_routing.py -q`
- `python -m pytest --collect-only`
- `python -m pytest tests/ -m "not assimulo" -rs`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,cr-at-eol diff --cached --check`

Notes: local tests used `/home/mlaljee/miniforge3/bin/python` (`Python 3.13.13`). The core lane passed with 44 selected tests, 4 expected skips because `assimulo` is not installed locally, and 6 marker deselections for the Assimulo lane.

<!-- gh-arc:metadata=start -->
## Review Follow-Up Metadata

<!-- gh-arc:metadata=review-audit-follow-up:sha=1ca37a77f6a1f9a04ccec89442763d14ca560f4c -->

- Pushed `1ca37a7` directly to existing branch `fix/issue-76-raw-material-opex`.
- Added NumPy-style docs for the PR-added raw-material test doubles and helper methods.
- Added bracketed units to raw-material expected values and tightened units/docs in touched OPEX/raw-material APIs.
- Kept broader pre-existing `SimExec.py` documentation/unit cleanup out of this PR and opened #129 for it.
- Existing follow-ups remain #127 for labor-cost docs and #128 for cost-constant references.
- Verification: test docstring audit clean; unit audit passed; focused tests `11 passed`; full suite `62 passed, 2 warnings`; CRLF-aware diff check passed; CI green.
<!-- gh-arc:metadata=end -->

