### PR TITLE
Replace bare except clauses with specific exceptions

### DIFF
--- a/PharmaPy/Crystallizers.py
+++ b/PharmaPy/Crystallizers.py
@@ -33,6 +33,7 @@ from scipy.optimize import newton
 
 import copy
 import string
+import warnings
 
 # try:
 #     from jax import jacfwd
@@ -121,8 +122,11 @@ class _BaseCryst:
             try:
                 import jax.numpy as np
                 _BaseCryst.np = np
-            except:
-                pass
+            except ImportError:
+                warnings.warn(
+                    "jac_type='AD' requires jax, which could not be "
+                    "imported. Falling back to numpy.",
+                    RuntimeWarning)
 
         self.distributed_uo = False
         self.mask_params = mask_params

--- a/PharmaPy/StatsModule.py
+++ b/PharmaPy/StatsModule.py
@@ -410,7 +410,7 @@ class StatisticsClass:
                     method=self.inst.opt_method,
                     verbose=False, store_iter=False,
                     optim_options=self.inst.optim_options)
-            except:
+            except Exception:
                 print('Optimization failed.')
                 params = [np.nan] * self.inst.num_params
 

--- a/PharmaPy/ThermoModule.py
+++ b/PharmaPy/ThermoModule.py
@@ -79,8 +79,8 @@ def ParseDatabase(path_datafile, to_arrays=True):
                 props = vals
             try:
                 props = np.array(props, dtype=float)
-            except:
-                pass
+            except (ValueError, TypeError):
+                pass  # non-numeric property (e.g. strings), keep as list
 
             dd_arrays[key] = props
 

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -1,0 +1,124 @@
+import json
+import sys
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+from PharmaPy.StatsModule import StatisticsClass
+from PharmaPy.ThermoModule import ParseDatabase
+
+
+pytestmark = pytest.mark.unit
+
+
+def _stub_assimulo_modules(monkeypatch):
+    assimulo = ModuleType("assimulo")
+
+    solvers = ModuleType("assimulo.solvers")
+    solvers.CVode = object
+
+    problem = ModuleType("assimulo.problem")
+    problem.Explicit_Problem = object
+
+    exception = ModuleType("assimulo.exception")
+    exception.TerminateSimulation = Exception
+
+    monkeypatch.setitem(sys.modules, "assimulo", assimulo)
+    monkeypatch.setitem(sys.modules, "assimulo.solvers", solvers)
+    monkeypatch.setitem(sys.modules, "assimulo.problem", problem)
+    monkeypatch.setitem(sys.modules, "assimulo.exception", exception)
+
+
+def _import_batch_cryst(monkeypatch):
+    try:
+        from PharmaPy.Crystallizers import BatchCryst
+    except ModuleNotFoundError as exc:
+        if exc.name != "assimulo":
+            raise
+        _stub_assimulo_modules(monkeypatch)
+
+        from PharmaPy.Crystallizers import BatchCryst
+
+    return BatchCryst
+
+
+class _FakeEstimationInstance:
+    def __init__(self, optimize_fn):
+        self.num_params = 2
+        self.opt_method = "LM"
+        self.optim_options = {}
+        self.y_data = None
+        self.optimize_fn = optimize_fn
+
+
+def _make_statistics(optimize_fn):
+    stats = StatisticsClass.__new__(StatisticsClass)
+    stats.inst = _FakeEstimationInstance(optimize_fn)
+    stats.get_bootsamples = lambda num_samples: [np.zeros(num_samples)]
+
+    return stats
+
+
+def test_parse_database_converts_numeric_fields_to_float_arrays(tmp_path):
+    database = {
+        "water": {"mw": 18.02, "cas": "7732-18-5"},
+        "ethanol": {"mw": 46.07, "cas": "64-17-5"},
+    }
+    path = tmp_path / "compounds.json"
+    path.write_text(json.dumps(database))
+
+    parsed = ParseDatabase(str(path))
+
+    assert isinstance(parsed["mw"], np.ndarray)
+    assert parsed["mw"].dtype == np.float64
+    np.testing.assert_allclose(sorted(parsed["mw"]), [18.02, 46.07])
+
+
+def test_parse_database_keeps_non_numeric_fields_as_lists(tmp_path):
+    database = {
+        "water": {"mw": 18.02, "cas": "7732-18-5"},
+        "ethanol": {"mw": 46.07, "cas": "64-17-5"},
+    }
+    path = tmp_path / "compounds.json"
+    path.write_text(json.dumps(database))
+
+    parsed = ParseDatabase(str(path))
+
+    assert isinstance(parsed["cas"], list)
+    assert sorted(parsed["cas"]) == ["64-17-5", "7732-18-5"]
+
+
+def test_bootstrap_params_records_nan_rows_for_failed_optimizations():
+    def failing_optimize(**kwargs):
+        raise RuntimeError("solver blew up")
+
+    stats = _make_statistics(failing_optimize)
+
+    stats.bootstrap_params(num_samples=3)
+
+    assert stats.boot_params.shape == (3, 2)
+    assert np.isnan(stats.boot_params).all()
+
+
+def test_bootstrap_params_does_not_swallow_keyboard_interrupt():
+    def interrupted_optimize(**kwargs):
+        raise KeyboardInterrupt
+
+    stats = _make_statistics(interrupted_optimize)
+
+    with pytest.raises(KeyboardInterrupt):
+        stats.bootstrap_params(num_samples=3)
+
+
+def test_batch_cryst_warns_when_ad_requested_without_jax(monkeypatch):
+    BatchCryst = _import_batch_cryst(monkeypatch)
+
+    monkeypatch.setitem(sys.modules, "jax", None)
+    monkeypatch.delitem(sys.modules, "jax.numpy", raising=False)
+
+    with pytest.warns(RuntimeWarning, match="jax"):
+        crystallizer = BatchCryst(target_comp="solute", jac_type="AD")
+
+    assert crystallizer.jac_type == "AD"
+    assert type(crystallizer).np is np


### PR DESCRIPTION
Part of #11 (finding 2), following the issue's suggestion to split the hygiene work into separate small PRs — this one only narrows the package's three bare `except:` clauses.

- **`ThermoModule.ParseDatabase`** — catches `(ValueError, TypeError)` around the float-array conversion, preserving the existing keep-as-list fallback for non-numeric property fields (e.g. CAS strings) while no longer swallowing unrelated errors.
- **`StatsModule.bootstrap_params`** — catches `Exception`, so a failed optimization still records a NaN row and continues, but `KeyboardInterrupt`/`SystemExit` now propagate — previously a user could not Ctrl-C out of a long bootstrap run.
- **`Crystallizers._BaseCryst`** — catches `ImportError` and emits a `RuntimeWarning` when `jac_type='AD'` is requested but jax cannot be imported, instead of silently falling back to numpy. Kept minimal on purpose: the AD jacobian methods are currently commented out and #11's dead-code task already flags this jax block, so this preserves behavior until that cleanup lands.

Each behavioral change has a regression test that fails against the previous code (KeyboardInterrupt propagation; the jax fallback warning), plus tests pinning the intended fallback behaviors. `flake8 --select=E722` now reports zero violations in `PharmaPy/`; wiring lint enforcement into CI is left to a separate #11 sub-PR.

Verified with `python -m pytest tests/ -m "not assimulo"`: 45 passed, 4 skipped.